### PR TITLE
Refactor Win32Error.

### DIFF
--- a/src/Boring32.Tests/main.cpp
+++ b/src/Boring32.Tests/main.cpp
@@ -23,7 +23,7 @@ void SearchTokenForAdminGroup()
 	// Open a handle to the access token for the calling process.
 	Boring32::RAII::Win32Handle hToken;
 	if (!Boring32::Win32::OpenProcessToken(Boring32::Win32::GetCurrentProcess(), Boring32::Win32::_TOKEN_QUERY, &hToken))
-		throw Boring32::Error::Win32Error("OpenProcessToken() failed", Boring32::Win32::GetLastError());
+		throw Boring32::Error::Win32Error(Boring32::Win32::GetLastError(), "OpenProcessToken() failed");
 
 	// Create a SID for the BUILTIN\Administrators group.
 	Boring32::Win32::PSID rawSID = nullptr;
@@ -37,7 +37,7 @@ void SearchTokenForAdminGroup()
 		&rawSID
 	);
 	if (!succeeded) 
-		throw Boring32::Error::Win32Error("AllocateAndInitializeSid() failed", Boring32::Win32::GetLastError());
+		throw Boring32::Error::Win32Error(Boring32::Win32::GetLastError(), "AllocateAndInitializeSid() failed");
 
 	Boring32::RAII::SIDUniquePtr pSID(rawSID);
 	if (Boring32::Security::SearchTokenGroupsForSID(hToken, pSID.get()))
@@ -51,7 +51,7 @@ void EnumerateTokenGroups()
 	// Open a handle to the access token for the calling process.
 	Boring32::RAII::Win32Handle hToken;
 	if (!OpenProcessToken(GetCurrentProcess(), Boring32::Win32::_TOKEN_QUERY, &hToken))
-		throw Boring32::Error::Win32Error("OpenProcessToken() failed", GetLastError());
+		throw Boring32::Error::Win32Error(GetLastError(), "OpenProcessToken() failed");
 	Boring32::Security::EnumerateTokenGroups(hToken);
 }
 
@@ -60,7 +60,7 @@ void EnumerateTokenPrivileges()
 	// Open a handle to the access token for the calling process.
 	Boring32::RAII::Win32Handle hToken;
 	if (!Boring32::Win32::OpenProcessToken(GetCurrentProcess(), Boring32::Win32::_TOKEN_QUERY, &hToken))
-		throw Boring32::Error::Win32Error("OpenProcessToken() failed", GetLastError());
+		throw Boring32::Error::Win32Error(GetLastError(), "OpenProcessToken() failed");
 	Boring32::Security::EnumerateTokenPrivileges(hToken);
 }
 

--- a/src/Boring32.UnitTests/Error/boring32.error-win32error.cpp
+++ b/src/Boring32.UnitTests/Error/boring32.error-win32error.cpp
@@ -19,7 +19,7 @@ namespace Error
 
 			TEST_METHOD(TestCopyConstructor)
 			{
-				Boring32::Error::Win32Error error1(m_errorMessage, 0x5);
+				Boring32::Error::Win32Error error1(0x5, m_errorMessage);
 				Boring32::Error::Win32Error error2(error1);
 				Assert::IsTrue(std::string(error1.what()) == std::string(error2.what()));
 				Assert::IsTrue(error1.GetErrorCode() == error2.GetErrorCode());
@@ -27,7 +27,7 @@ namespace Error
 
 			TEST_METHOD(TestCopyAssignment)
 			{
-				Boring32::Error::Win32Error error1(m_errorMessage, 0x5);
+				Boring32::Error::Win32Error error1(0x5, m_errorMessage);
 				Boring32::Error::Win32Error error2 = error1;
 				Assert::IsTrue(std::string(error1.what()) == std::string(error2.what()));
 				Assert::IsTrue(error1.GetErrorCode() == error2.GetErrorCode());
@@ -35,7 +35,7 @@ namespace Error
 
 			TEST_METHOD(TestMoveConstructor)
 			{
-				Boring32::Error::Win32Error error1(m_errorMessage, 0x5);
+				Boring32::Error::Win32Error error1(0x5, m_errorMessage);
 				Boring32::Error::Win32Error error2(std::move(error1));
 				Assert::IsFalse(std::string(error2.what()).empty());
 				Assert::IsTrue(error2.GetErrorCode() == 0x5);
@@ -43,7 +43,7 @@ namespace Error
 
 			TEST_METHOD(TestMoveAssignment)
 			{
-				Boring32::Error::Win32Error error1(m_errorMessage, 0x5);
+				Boring32::Error::Win32Error error1(0x5, m_errorMessage);
 				Boring32::Error::Win32Error error2 = std::move(error1);
 				Assert::IsFalse(std::string(error2.what()).empty());
 				Assert::IsTrue(error2.GetErrorCode() == 0x5);
@@ -51,8 +51,8 @@ namespace Error
 
 			TEST_METHOD(TestGetErrorCode)
 			{
-				Boring32::Error::Win32Error error1(m_errorMessage, 0x5);
-				Boring32::Error::Win32Error error2(m_errorMessage, 0x6);
+				Boring32::Error::Win32Error error1(0x5, m_errorMessage);
+				Boring32::Error::Win32Error error2(0x6, m_errorMessage);
 				Assert::IsTrue(error1.GetErrorCode() == 0x5);
 				Assert::IsTrue(error2.GetErrorCode() == 0x6);
 			}

--- a/src/Boring32/Async/boring32-async_apcthread.ixx
+++ b/src/Boring32/Async/boring32-async_apcthread.ixx
@@ -57,10 +57,8 @@ export namespace Boring32::Async
 						int(m_status)
 					)
 				);
-
-			Win32::DWORD status = Win32::QueueUserAPC(apc, m_threadHandle, arg);
-			if (auto lastError = Win32::GetLastError(); not status)
-				throw Error::Win32Error("QueueUserAPC() failed", lastError);
+			if (not Win32::QueueUserAPC(apc, m_threadHandle, arg))
+				throw Error::Win32Error(Win32::GetLastError(), "QueueUserAPC() failed");
 		}
 
 		auto SignalToExit() -> void

--- a/src/Boring32/Async/boring32-async_cmdrunner.ixx
+++ b/src/Boring32/Async/boring32-async_cmdrunner.ixx
@@ -61,8 +61,8 @@ namespace Boring32::Async
             &siStartInfo,  // STARTUPINFO pointer 
             &piProcInfo     // receives PROCESS_INFORMATION 
         );
-        if (auto lastError = Win32::GetLastError(); not bSuccess)
-            throw Error::Win32Error("CreateProcessW() failed", lastError);
+        if (not bSuccess)
+            throw Error::Win32Error(Win32::GetLastError(), "CreateProcessW() failed");
 
         return piProcInfo;
     }
@@ -114,26 +114,26 @@ export namespace Boring32::Async
         // Create a pipe for the child process's STDOUT. 
         Win32::HANDLE hChildStd_OUT_Rd = nullptr;
         Win32::HANDLE hChildStd_OUT_Wr = nullptr;
-        if (auto lastError = GetLastError(); not Win32::CreatePipe(&hChildStd_OUT_Rd, &hChildStd_OUT_Wr, &saAttr, 0))
-            throw Error::Win32Error("CreatePipe() failed", lastError);
+        if (not Win32::CreatePipe(&hChildStd_OUT_Rd, &hChildStd_OUT_Wr, &saAttr, 0))
+            throw Error::Win32Error(GetLastError(), "CreatePipe() failed");
         HandleUniquePtr ptrChildStdOutWr = HandleUniquePtr(hChildStd_OUT_Wr);
         HandleUniquePtr ptrChildStdOutRd = HandleUniquePtr(hChildStd_OUT_Rd);
 
         // Ensure the read handle to the pipe for STDOUT is not inherited.
-        if (auto lastError = GetLastError(); not Win32::SetHandleInformation(hChildStd_OUT_Rd, Win32::HandleFlagInherit, 0))
-            throw Error::Win32Error("CreatePipe() failed", lastError);
+        if (not Win32::SetHandleInformation(hChildStd_OUT_Rd, Win32::HandleFlagInherit, 0))
+            throw Error::Win32Error(GetLastError(), "CreatePipe() failed");
 
         // Create a pipe for the child process's STDIN. 
         Win32::HANDLE hChildStd_IN_Rd = nullptr;
         Win32::HANDLE hChildStd_IN_Wr = nullptr;
-        if (auto lastError = GetLastError(); not Win32::CreatePipe(&hChildStd_IN_Rd, &hChildStd_IN_Wr, &saAttr, 0))
-            throw Error::Win32Error("CreatePipe() failed", lastError);
+        if (not Win32::CreatePipe(&hChildStd_IN_Rd, &hChildStd_IN_Wr, &saAttr, 0))
+            throw Error::Win32Error(GetLastError(), "CreatePipe() failed");
         HandleUniquePtr ptrChildStdInRd = HandleUniquePtr(hChildStd_IN_Rd);
         HandleUniquePtr ptrChildStdInWr = HandleUniquePtr(hChildStd_IN_Wr);
 
         // Ensure the write handle to the pipe for STDIN is not inherited. 
-        if (auto lastError = GetLastError(); not Win32::SetHandleInformation(hChildStd_IN_Wr, Win32::HandleFlagInherit, 0))
-            throw Error::Win32Error("CreatePipe() failed", lastError);
+        if (not Win32::SetHandleInformation(hChildStd_IN_Wr, Win32::HandleFlagInherit, 0))
+            throw Error::Win32Error(GetLastError(), "CreatePipe() failed");
 
         // Create the child process. 
         Win32::PROCESS_INFORMATION childProc = CreateChildProcess(

--- a/src/Boring32/Async/boring32-async_criticalsection.ixx
+++ b/src/Boring32/Async/boring32-async_criticalsection.ixx
@@ -51,16 +51,8 @@ export namespace Boring32::Async
 		void Initialise(const Win32::DWORD spinCount)
 		{
 			// https://learn.microsoft.com/en-us/windows/win32/api/synchapi/nf-synchapi-initializecriticalsectionex
-			const bool success = Win32::InitializeCriticalSectionEx(
-				&m_criticalSection,
-				spinCount,
-				0
-			);
-			if (not success)
-			{
-				const auto lastError = Win32::GetLastError();
-				throw Error::Win32Error("InitializeCriticalSectionEx() failed", lastError);
-			}
+			if (not Win32::InitializeCriticalSectionEx(&m_criticalSection, spinCount, 0))
+				throw Error::Win32Error(Win32::GetLastError(), "InitializeCriticalSectionEx() failed");
 		}
 
 		Win32::CRITICAL_SECTION m_criticalSection;

--- a/src/Boring32/Async/boring32-async_eventloop.ixx
+++ b/src/Boring32/Async/boring32-async_eventloop.ixx
@@ -39,10 +39,7 @@ export namespace Boring32::Async
 				true
 			);
 			if (result == Win32::WaitFailed)
-			{
-				const auto lastError = Win32::GetLastError();
-				throw Error::Win32Error("WaitForMultipleObjectsEx() failed", lastError);
-			}
+				throw Error::Win32Error(Win32::GetLastError(), "WaitForMultipleObjectsEx() failed");
 			if (result == Win32::WaitTimeout)
 				return false;
 			if (result >= Win32::WaitAbandoned && result <= (Win32::WaitAbandoned + m_events.size() - 1))

--- a/src/Boring32/Async/boring32-async_filemapping.ixx
+++ b/src/Boring32/Async/boring32-async_filemapping.ixx
@@ -127,8 +127,8 @@ export namespace Boring32::Async
 				li.LowPart,				// maximum object size (low-order DWORD)
 				name					// m_name of mapping object
 			);
-			if (auto lastError = Win32::GetLastError(); not m_fileMapping)
-				throw Error::Win32Error("CreateFileMappingW() failed", lastError);
+			if (not m_fileMapping)
+				throw Error::Win32Error(Win32::GetLastError(), "CreateFileMappingW() failed");
 
 			m_fileMapping.SetInheritability(isInheritable);
 		}
@@ -144,8 +144,8 @@ export namespace Boring32::Async
 				isInheritable,						// Should the handle be inheritable
 				m_name.c_str()						// name of mapping object
 			);
-			if (auto lastError = Win32::GetLastError(); not m_fileMapping)
-				throw Error::Win32Error("OpenFileMappingW() failed", lastError);
+			if (not m_fileMapping)
+				throw Error::Win32Error(Win32::GetLastError(), "OpenFileMappingW() failed");
 		}
 
 		FileMapping& Copy(const FileMapping& other)

--- a/src/Boring32/Async/boring32-async_functions.ixx
+++ b/src/Boring32/Async/boring32-async_functions.ixx
@@ -55,13 +55,7 @@ export namespace Boring32::Async
 				throw Error::Boring32Error("The wait was abandoned");
 
 			case Win32::WaitResult::Failed:
-			{
-				const auto lastError = Win32::GetLastError();
-				throw Error::Win32Error(
-					"WaitForSingleObjectEx() failed",
-					lastError
-				);
-			}
+				throw Error::Win32Error(Win32::GetLastError(), "WaitForSingleObjectEx() failed");
 
 			default:
 				throw Error::Boring32Error(std::format("Unknown wait status: {}", (unsigned long)status));
@@ -147,13 +141,7 @@ export namespace Boring32::Async
 				return status;
 
 			case Win32::WaitFailed:
-			{
-				const auto lastError = Win32::GetLastError();
-				throw Error::Win32Error(
-					"WaitForSingleObjectEx() failed",
-					lastError
-				);
-			}
+				throw Error::Win32Error(Win32::GetLastError(), "WaitForSingleObjectEx() failed");
 
 			default:
 				return waitForAll ? 0 : status - Win32::WaitObject0;
@@ -221,24 +209,12 @@ export namespace Boring32::Async
 		// https://docs.microsoft.com/en-us/windows/win32/api/tlhelp32/nf-tlhelp32-createtoolhelp32snapshot
 		RAII::Win32Handle processesSnapshot = Win32::CreateToolhelp32Snapshot(Win32::Th32csSnapProcess, 0);
 		if (processesSnapshot == Win32::InvalidHandleValue)
-		{
-			const auto lastError = Win32::GetLastError();
-			throw Error::Win32Error(
-				"CreateToolhelp32Snapshot() failed",
-				lastError
-			);
-		}
+			throw Error::Win32Error(Win32::GetLastError(), "CreateToolhelp32Snapshot() failed");
 
 		Win32::PROCESSENTRY32W procEntry{ .dwSize = sizeof(Win32::PROCESSENTRY32W) };
 		// https://docs.microsoft.com/en-us/windows/win32/api/tlhelp32/nf-tlhelp32-process32firstw
 		if (!Win32::Process32FirstW(processesSnapshot.GetHandle(), &procEntry))
-		{
-			const auto lastError = Win32::GetLastError();
-			throw Error::Win32Error(
-				"Process32First() failed",
-				lastError
-			);
-		}
+			throw Error::Win32Error(Win32::GetLastError(), "Process32First() failed");
 
 		std::vector<Win32::DWORD> results;
 		do
@@ -255,13 +231,7 @@ export namespace Boring32::Async
 			Win32::DWORD processSessionId = 0;
 			// https://docs.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-processidtosessionid
 			if (!Win32::ProcessIdToSessionId(procEntry.th32ProcessID, &processSessionId))
-			{
-				const auto lastError = Win32::GetLastError();
-				throw Error::Win32Error(
-					"ProcessIdToSessionId() failed",
-					lastError
-				);
-			}
+				throw Error::Win32Error(Win32::GetLastError(), "ProcessIdToSessionId() failed");
 
 			if (processSessionId == sessionIdToMatch)
 			{

--- a/src/Boring32/Async/boring32-async_job.ixx
+++ b/src/Boring32/Async/boring32-async_job.ixx
@@ -35,37 +35,24 @@ export namespace Boring32::Async
 			// See https://docs.microsoft.com/en-us/windows/win32/api/winnt/ns-winnt-jobobject_basic_limit_information
 			// jeli.BasicLimitInformation.LimitFlags = JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE;
 
-			const bool succeeded = Win32::SetInformationJobObject(
+			bool succeeded = Win32::SetInformationJobObject(
 				m_job.GetHandle(),
 				Win32::JOBOBJECTINFOCLASS::JobObjectExtendedLimitInformation,
 				&jeli,
 				sizeof(jeli)
 			);
-			if (!succeeded)
-			{
-				const auto lastError = Win32::GetLastError();
-				throw Error::Win32Error(
-					"SetInformationJobObject() failed",
-					lastError
-				);
-			}
+			if (not succeeded)
+				throw Error::Win32Error(Win32::GetLastError(), "SetInformationJobObject() failed");
 		}
 
 		void AssignProcessToThisJob(const Win32::HANDLE process)
 		{
-			if (!m_job)
+			if (not m_job)
 				throw Error::Boring32Error("Cannot assign process to job; job is not initialised");
-			if (!process)
+			if (not process)
 				throw Error::Boring32Error("Cannot assign process to job; process is null.");
-
-			if (!Win32::AssignProcessToJobObject(m_job.GetHandle(), process))
-			{
-				const auto lastError = Win32::GetLastError();
-				throw Error::Win32Error(
-					"Cannot assign process to job; AssignProcessToJobObject() failed.",
-					lastError
-				);
-			}
+			if (not Win32::AssignProcessToJobObject(m_job.GetHandle(), process))
+				throw Error::Win32Error(Win32::GetLastError(), "Cannot assign process to job; AssignProcessToJobObject() failed.");
 		}
 
 		Win32::HANDLE GetHandle() const noexcept
@@ -91,18 +78,9 @@ export namespace Boring32::Async
 		private:
 		void Create(const bool isInheritable)
 		{
-			m_job = Win32::CreateJobObjectW(
-				nullptr,
-				m_name.empty() ? nullptr : m_name.c_str()
-			);
-			if (!m_job)
-			{
-				const auto lastError = Win32::GetLastError();
-				throw Error::Win32Error(
-					"CreateJobObjectW() failed",
-					lastError
-				);
-			}
+			m_job = Win32::CreateJobObjectW(nullptr, m_name.empty() ? nullptr : m_name.c_str());
+			if (not m_job)
+				throw Error::Win32Error(Win32::GetLastError(), "CreateJobObjectW() failed");
 			m_job.SetInheritability(isInheritable);
 		}
 
@@ -113,14 +91,8 @@ export namespace Boring32::Async
 				isInheritable,
 				m_name.c_str()
 			);
-			if (!m_job)
-			{
-				const auto lastError = Win32::GetLastError();
-				throw Error::Win32Error(
-					"OpenJobObjectW() failed",
-					lastError
-				);
-			}
+			if (not m_job)
+				throw Error::Win32Error(Win32::GetLastError(), "OpenJobObjectW() failed");
 		}
 
 		RAII::Win32Handle m_job;

--- a/src/Boring32/Async/boring32-async_memorymappedfile.ixx
+++ b/src/Boring32/Async/boring32-async_memorymappedfile.ixx
@@ -64,8 +64,8 @@ export namespace Boring32::Async
 				m_maxSize,					// maximum object size (low-order DWORD)
 				m_name.c_str()				// m_name of mapping object
 			);
-			if (auto lastError = Win32::GetLastError(); not m_mapFile)
-				throw Error::Win32Error("CreateFileMappingW() failed", lastError);
+			if (not m_mapFile)
+				throw Error::Win32Error(Win32::GetLastError(), "CreateFileMappingW() failed");
 
 			m_mapFile.SetInheritability(inheritable);
 			m_view = Win32::MapViewOfFile(
@@ -75,10 +75,11 @@ export namespace Boring32::Async
 				0,
 				maxSize
 			);
-			if (auto lastError = Win32::GetLastError(); not m_view)
+			if (not m_view)
 			{
+				auto lastError = Win32::GetLastError();
 				Close();
-				throw Error::Win32Error("MapViewOfFile() failed", lastError);
+				throw Error::Win32Error(lastError, "MapViewOfFile() failed");
 			}
 
 			Win32::RtlSecureZeroMemory(m_view, m_maxSize);
@@ -99,8 +100,8 @@ export namespace Boring32::Async
 				inheritable,	// Should the handle be inheritable
 				m_name.c_str()	// name of mapping object
 			);
-			if (auto lastError = Win32::GetLastError(); not m_mapFile)
-				throw Error::Win32Error("OpenFileMappingW() failed", lastError);
+			if (not m_mapFile)
+				throw Error::Win32Error(Win32::GetLastError(), "OpenFileMappingW() failed");
 
 			m_view = Win32::MapViewOfFile(
 				m_mapFile.GetHandle(),	// handle to map object
@@ -109,10 +110,11 @@ export namespace Boring32::Async
 				0,
 				maxSize
 			);
-			if (auto lastError = Win32::GetLastError(); not m_view)
+			if (not m_view)
 			{
+				auto lastError = Win32::GetLastError();
 				Close();
-				throw Error::Win32Error("MapViewOfFile() failed", lastError);
+				throw Error::Win32Error(lastError, "MapViewOfFile() failed");
 			}
 		}
 
@@ -138,8 +140,8 @@ export namespace Boring32::Async
 		///	Releases all resources owned by this object.
 		void Close()
 		{
-			if (auto lastError = Win32::GetLastError(); m_view && !Win32::UnmapViewOfFile(m_view))
-				throw Error::Win32Error("UnmapViewOfFile() failed", lastError);
+			if (m_view && !Win32::UnmapViewOfFile(m_view))
+				throw Error::Win32Error(Win32::GetLastError(), "UnmapViewOfFile() failed");
 			m_view = nullptr;
 			m_mapFile = nullptr;
 		}
@@ -183,10 +185,11 @@ export namespace Boring32::Async
 				0,
 				m_maxSize
 			);
-			if (auto lastError = Win32::GetLastError(); not m_view)
+			if (not m_view)
 			{
+				auto lastError = Win32::GetLastError();
 				Close();
-				throw Error::Win32Error("MapViewOfFile() failed", lastError);
+				throw Error::Win32Error(lastError, "MapViewOfFile() failed");
 			}
 		}
 

--- a/src/Boring32/Async/boring32-async_mutex.ixx
+++ b/src/Boring32/Async/boring32-async_mutex.ixx
@@ -7,303 +7,174 @@ import :async_functions;
 
 export namespace Boring32::Async
 {
-	/// <summary>
 	///		Represents a Win32 mutex, an object used for interprocess
 	///		synchronisation and communication.
-	/// </summary>
-	class Mutex final
+	struct Mutex final
 	{
-		// The six
-		public:
-			/// <summary>
-			/// Default constructor. Does not initialise any underlying mutex.
-			/// </summary>
-			Mutex() = default;
+		/// Default constructor. Does not initialise any underlying mutex.
+		Mutex() = default;
 
-			/// <summary>
-			///		Move constructor.
-			/// </summary>
-			/// <param name="other">The rvalue to move.</param>
-			Mutex(Mutex&& other) noexcept
-			{
-				Move(other);
-			}
+		///		Move constructor.
+		Mutex(Mutex&& other) noexcept
+		{
+			Move(other);
+		}
 
-			/// <summary>
-			///		Move assignment.
-			/// </summary>
-			Mutex& operator=(Mutex&& other) noexcept
-			{
-				Move(other);
-				return *this;
-			}
+		///		Move assignment.
+		Mutex& operator=(Mutex&& other) noexcept
+		{
+			Move(other);
+			return *this;
+		}
 
-			/// <summary>
-			///		Destructor.
-			/// </summary>
-			~Mutex()
-			{
-				Close();
-			}
+		~Mutex()
+		{
+			Close();
+		}
 
-			// Custom constructors
-		public:
-			/// <summary>
-			///		Creates an anonymous mutex.
-			/// </summary>
-			/// <param name="acquire">
-			///		Whether to request acquisition of the mutex.
-			/// </param>
-			/// <param name="inheritable">
-			///		Whether the mutex is inheritable to child processes.
-			/// </param>
-			/// <exception cref="std::runtime_error">
-			///		Thrown when mutex creation failed.
-			/// </exception>
-			Mutex(const bool acquire, const bool inheritable)
-				: m_locked(acquire)
-			{
-				m_mutex = Win32::CreateMutexW(
-					nullptr,
-					m_locked,
-					nullptr
-				);
-				m_mutex.SetInheritability(inheritable);
-				if (!m_mutex)
-				{
-					const auto lastError = Win32::GetLastError();
-					throw Error::Win32Error("Failed to create mutex", lastError);
-				}
-			}
+		///		Creates an anonymous mutex.
+		Mutex(bool acquire, bool inheritable)
+			: m_locked(acquire)
+		{
+			m_mutex = Win32::CreateMutexW(nullptr, m_locked, nullptr);
+			m_mutex.SetInheritability(inheritable);
+			if (not m_mutex)
+				throw Error::Win32Error(Win32::GetLastError(), "Failed to create mutex");
+		}
 
-			/// <summary>
-			///		Creates a new named or anonymous mutex.
-			/// </summary>
-			/// <param name="name">
-			///		The name of the mutex to create. Pass an empty
-			///		string to create an anonymous mutex.
-			/// </param>
-			/// <param name="acquireOnCreation">
-			///		Whether to acquire the mutex on creation.
-			/// </param>
-			/// <param name="inheritable">
-			///		Whether the handle can be inherited by child processes.
-			/// </param>
-			Mutex(
-				const bool acquireOnCreation,
-				const bool inheritable,
-				std::wstring name
-			) : m_name(std::move(name)),
-				m_created(true)
-			{
-				m_mutex = Win32::CreateMutexW(
-					nullptr,
-					acquireOnCreation,
-					m_name.empty() ? nullptr : m_name.c_str()
-				);
-				m_mutex.SetInheritability(inheritable);
-				if (!m_mutex)
-				{
-					const auto lastError = Win32::GetLastError();
-					throw Error::Win32Error("Failed to create mutex", lastError);
-				}
+		///		Creates a new named or anonymous mutex.
+		Mutex(bool acquireOnCreation, bool inheritable, std::wstring name) 
+			: m_name(std::move(name)),
+			m_created(true)
+		{
+			m_mutex = Win32::CreateMutexW(
+				nullptr,
+				acquireOnCreation,
+				m_name.empty() ? nullptr : m_name.c_str()
+			);
+			m_mutex.SetInheritability(inheritable);
+			if (not m_mutex)
+				throw Error::Win32Error(Win32::GetLastError(), "Failed to create mutex");
 
-				m_locked = acquireOnCreation;
-			}
+			m_locked = acquireOnCreation;
+		}
 
-			/// <summary>
-			///		Opens an existing named mutex.
-			/// </summary>
-			/// <param name="inheritable">
-			///		Whether the handle can be inherited by child processes.
-			/// </param>
-			/// <param name="name">
-			///		The name of the mutex to open. Must not be the empty string.
-			/// </param>
-			/// <param name="desiredAccess">
-			///		The desired access to open the mutex, e.g. SYNCHRONIZE.
-			/// </param>
-			Mutex(
-				const bool acquireOnOpen,
-				const bool isInheritable,
-				std::wstring name,
-				const Win32::DWORD desiredAccess
-			) : m_name(name)
-			{
-				if (m_name.empty())
-					throw Error::Boring32Error("Cannot open mutex with empty name");
-				m_mutex = Win32::OpenMutexW(desiredAccess, isInheritable, m_name.c_str());
-				if (!m_mutex)
-				{
-					const auto lastError = Win32::GetLastError();
-					throw Error::Win32Error("Failed to open mutex", lastError);
-				}
-				if (acquireOnOpen)
-					Lock(Win32::Infinite, true);
-			}
+		///		Opens an existing named mutex.
+		Mutex(bool acquireOnOpen, bool isInheritable, std::wstring name, Win32::DWORD desiredAccess) 
+			: m_name(name)
+		{
+			if (m_name.empty())
+				throw Error::Boring32Error("Cannot open mutex with empty name");
+			m_mutex = Win32::OpenMutexW(desiredAccess, isInheritable, m_name.c_str());
+			if (not m_mutex)
+				throw Error::Win32Error(Win32::GetLastError(), "Failed to open mutex");
+			if (acquireOnOpen)
+				Lock(Win32::Infinite, true);
+		}
 
-		// API
-		public:
-			bool Lock()
-			{
-				return Lock(Win32::Infinite, false);
-			}
+		bool Lock()
+		{
+			return Lock(Win32::Infinite, false);
+		}
 
-			bool Lock(const Win32::DWORD waitTime)
-			{
-				return Lock(waitTime, false);
-			}
+		bool Lock(Win32::DWORD waitTime)
+		{
+			return Lock(waitTime, false);
+		}
 
-			bool Lock(const bool isAlertable)
-			{
-				return Lock(Win32::Infinite, isAlertable);
-			}
+		bool Lock(bool isAlertable)
+		{
+			return Lock(Win32::Infinite, isAlertable);
+		}
 
-			bool Lock(
-				const Concepts::Duration auto& time,
-				const bool alertable
-			)
-			{
-				using std::chrono::duration_cast;
-				using std::chrono::milliseconds;
-				return Lock(
-					static_cast<Win32::DWORD>(duration_cast<milliseconds>(time).count()),
-					alertable
-				);
-			}
+		bool Lock(Concepts::Duration auto time, bool alertable)
+		{
+			using namespace std::chrono;
+			return Lock(static_cast<Win32::DWORD>(duration_cast<milliseconds>(time).count()), alertable);
+		}
 
-			/// <summary>
-			///		Blocks the current thread for a specified amount of time 
-			///		(or indefinitely) until the mutex is acquired.
-			/// </summary>
-			/// <param name="waitTime">
-			///		The time in milliseconds to wait to acquire the mutex.
-			///		Pass INFINITE to wait indefinitely.
-			/// </param>
-			/// <returns>
-			///		Returns true if the mutex was successfully acquired,
-			///		or false if the timeout occurred.
-			/// </returns>
-			/// <exception cref="Error::Boring32Error">
-			///		Mutex not initialised.
-			/// </exception>
-			bool Lock(const Win32::DWORD waitTime, const bool isAlertable)
-			{
-				if (!m_mutex)
-					throw Error::Boring32Error("Cannot wait on null mutex");
-				return m_locked = WaitFor(
-					m_mutex.GetHandle(), 
-					waitTime, 
-					isAlertable
-				) == Win32::WaitResult::Success;
-			}
+		///		Blocks the current thread for a specified amount of time 
+		///		(or indefinitely) until the mutex is acquired.
+		bool Lock(Win32::DWORD waitTime, bool isAlertable)
+		{
+			if (not m_mutex)
+				throw Error::Boring32Error("Cannot wait on null mutex");
+			return m_locked = WaitFor(m_mutex.GetHandle(), waitTime, isAlertable) == Win32::WaitResult::Success;
+		}
 
-			/// <summary>
-			///		Blocks the current thread for a specified amount of time 
-			///		(or indefinitely) until the mutex is acquired. Does not
-			///		throw exceptions on failure.
-			/// </summary>
-			/// <param name="waitTime">
-			///		The time in milliseconds to wait to acquire the mutex.
-			///		Pass INFINITE to wait indefinitely.
-			/// </param>
-			/// <returns>
-			///		Returns true if the mutex was successfully acquired,
-			///		or false if the timeout occurred, or if an error occurred.
-			/// </returns>
-			bool Lock(
-				const Win32::DWORD waitTime,
-				const bool isAlertable, 
-				const std::nothrow_t&
-			) noexcept try
-			{
-				return Lock(waitTime, isAlertable);
-			}
-			catch (const std::exception& ex)
-			{
-				std::wcerr << std::format("Lock() failed: {}\n", ex.what()).c_str();
-				return false;
-			}
+		///		Blocks the current thread for a specified amount of time 
+		///		(or indefinitely) until the mutex is acquired. Does not
+		///		throw exceptions on failure.
+		bool Lock(Win32::DWORD waitTime, bool isAlertable, std::nothrow_t) noexcept 
+		try
+		{
+			return Lock(waitTime, isAlertable);
+		}
+		catch (const std::exception&)
+		{
+			return false;
+		}
 
-			/// <summary>
-			///		Frees the mutex, allowing another process to acquire it.
-			/// </summary>
-			/// <exception cref="Error::Win32Error">
-			///		Failed to release the mutex.
-			/// </exception>
-			void Unlock()
-			{
-				if (!m_mutex)
-					throw Error::Boring32Error("Cannot wait on null mutex");
-				if (!Win32::ReleaseMutex(m_mutex.GetHandle()))
-				{
-					const auto lastError = Win32::GetLastError();
-					throw Error::Win32Error("Failed to release mutex", lastError);
-				}
+		///		Frees the mutex, allowing another process to acquire it.
+		void Unlock()
+		{
+			if (not m_mutex)
+				throw Error::Boring32Error("Cannot wait on null mutex");
+			if (not Win32::ReleaseMutex(m_mutex.GetHandle()))
+				throw Error::Win32Error(Win32::GetLastError(), "Failed to release mutex");
 
-				m_locked = false;
-			}
+			m_locked = false;
+		}
 
-			/// <summary>
-			///		Frees the mutex, allowing another process to acquire it.
-			///		Does not throw exceptions on failure.
-			/// </summary>
-			bool Unlock(const std::nothrow_t&) noexcept try
-			{
+		///		Frees the mutex, allowing another process to acquire it.
+		///		Does not throw exceptions on failure.
+		bool Unlock(const std::nothrow_t&) noexcept 
+		try
+		{
+			Unlock();
+			return true;
+		}
+		catch (const std::exception&)
+		{
+			return false;
+		}
+
+		///		Invalidates and closes the native Mutex handle.
+		void Close()
+		{
+			if (not m_mutex)
+				return;
+			if (m_locked)
 				Unlock();
-				return true;
-			}
-			catch (const std::exception& ex)
-			{
-				std::wcerr << std::format("Unlock() failed: {}\n", ex.what()).c_str();
-				return false;
-			}
+			m_mutex.Close();
+		}
 
-			/// <summary>
-			///		Invalidates and closes the native Mutex handle.
-			/// </summary>
-			void Close()
-			{
-				if (!m_mutex)
-					return;
-				if (m_locked)
-					Unlock();
-				m_mutex.Close();
-			}
+		///		Retrieves this Mutex's underlying handle.
+		Win32::HANDLE GetHandle() const noexcept
+		{
+			return m_mutex.GetHandle();
+		}
 
-			/// <summary>
-			///		Retrieves this Mutex's underlying handle.
-			/// </summary>
-			/// <returns>This Mutex's underlying handle</returns>
-			Win32::HANDLE GetHandle() const noexcept
-			{
-				return m_mutex.GetHandle();
-			}
-
-			/// <summary>
-			///		Retrieves this Mutex's name. This value is an empty string
-			///		if this is an anonymous Mutex.
-			/// </summary>
-			/// <returns>This Mutex's name.</returns>
-			const std::wstring& GetName() const noexcept
-			{
-				return m_name;
-			}
+		///	Retrieves this Mutex's name. This value is an empty string
+		///	if this is an anonymous Mutex.
+		const std::wstring& GetName() const noexcept
+		{
+			return m_name;
+		}
 
 		private:
-			void Move(Mutex& other) noexcept
-			{
-				Close();
-				m_name = std::move(other.m_name);
-				m_created = other.m_created;
-				m_locked = other.m_locked.load(); // TODO: probably pointless, remove
-				m_mutex = std::move(other.m_mutex);
-			}
+		void Move(Mutex& other) noexcept
+		{
+			Close();
+			m_name = std::move(other.m_name);
+			m_created = other.m_created;
+			m_locked = other.m_locked.load(); // TODO: probably pointless, remove
+			m_mutex = std::move(other.m_mutex);
+		}
 
-		private:
-			std::wstring m_name;
-			bool m_created = false;
-			std::atomic<bool> m_locked = false;
-			RAII::Win32Handle m_mutex;
+		std::wstring m_name;
+		bool m_created = false;
+		std::atomic<bool> m_locked = false;
+		RAII::Win32Handle m_mutex;
 	};
 }

--- a/src/Boring32/Async/boring32-async_process.ixx
+++ b/src/Boring32/Async/boring32-async_process.ixx
@@ -67,10 +67,7 @@ export namespace Boring32::Async
 					&processInfo			// Pointer to PROCESS_INFORMATION structure
 				);
 			if (!successfullyCreatedProcess)
-			{
-				const auto lastError = Win32::GetLastError();
-				throw Error::Win32Error("Failed to create process", lastError);
-			}
+				throw Error::Win32Error(Win32::GetLastError(), "Failed to create process");
 
 			m_process = processInfo.hProcess;
 			m_thread = processInfo.hThread;
@@ -135,8 +132,8 @@ export namespace Boring32::Async
 				throw Error::Boring32Error("No process handle to query");
 
 			Win32::DWORD exitCode = 0;
-			if (auto lastError = Win32::GetLastError(); not Win32::GetExitCodeProcess(m_process.GetHandle(), &exitCode))
-				throw Error::Win32Error("Failed to determine process exit code", lastError);
+			if (not Win32::GetExitCodeProcess(m_process.GetHandle(), &exitCode))
+				throw Error::Win32Error(Win32::GetLastError(), "Failed to determine process exit code");
 
 			return exitCode;
 		}

--- a/src/Boring32/Async/boring32-async_semaphore.ixx
+++ b/src/Boring32/Async/boring32-async_semaphore.ixx
@@ -53,8 +53,8 @@ export namespace Boring32::Async
 					throw Error::Boring32Error("MaxCount cannot be 0.");
 				//SEMAPHORE_ALL_ACCESS
 				m_handle = Win32::OpenSemaphoreW(desiredAccess, isInheritable, m_name.c_str());
-				if (auto lastError = Win32::GetLastError(); not m_handle)
-					throw Error::Win32Error("failed to open semaphore", lastError);
+				if (not m_handle)
+					throw Error::Win32Error(Win32::GetLastError(), "failed to open semaphore");
 			}
 			
 		operator bool() const noexcept
@@ -81,8 +81,8 @@ export namespace Boring32::Async
 				throw Error::Boring32Error("m_handle is nullptr.");
 
 			long previousCount;
-			if (auto lastError = GetLastError(); not Win32::ReleaseSemaphore(*m_handle, countToRelease, &previousCount))
-				throw Error::Win32Error("Failed to release semaphore", lastError);
+			if (not Win32::ReleaseSemaphore(*m_handle, countToRelease, &previousCount))
+				throw Error::Win32Error(Win32::GetLastError(), "Failed to release semaphore");
 		}
 
 		bool Acquire()
@@ -144,10 +144,7 @@ export namespace Boring32::Async
 					throw Error::Boring32Error("The wait was abandoned.");
 
 				case Win32::WaitFailed:
-				{
-					const auto lastError = Win32::GetLastError();
-					throw Error::Win32Error("WaitForSingleObject() failed", lastError);
-				}
+					throw Error::Win32Error(Win32::GetLastError(), "WaitForSingleObject() failed");
 
 				default:
 					throw Error::Boring32Error(
@@ -192,8 +189,8 @@ export namespace Boring32::Async
 				maxCount,
 				name.empty() ? nullptr : name.c_str()
 			);
-			if (auto lastError = Win32::GetLastError(); not m_handle)
-				throw Error::Win32Error("Failed to create or open semaphore", lastError);
+			if (not m_handle)
+				throw Error::Win32Error(Win32::GetLastError(), "Failed to create or open semaphore");
 
 			m_handle.SetInheritability(isInheritable);
 		}

--- a/src/Boring32/Async/boring32-async_synchronizationbarrier.ixx
+++ b/src/Boring32/Async/boring32-async_synchronizationbarrier.ixx
@@ -14,16 +14,11 @@ export namespace Boring32::Async
 		SynchronizationBarrier() = default;
 		SynchronizationBarrier(const long totalThreads, const long spinCount)
 			: m_totalThreads(totalThreads),
-			m_spinCount(spinCount),
-			m_isInitialized(false),
-			m_barrier{ 0 }
+			m_spinCount(spinCount)
 		{
 			//https://docs.microsoft.com/en-us/windows/win32/api/synchapi/nf-synchapi-initializesynchronizationbarrier
-			if (!Win32::InitializeSynchronizationBarrier(&m_barrier, m_totalThreads, m_spinCount))
-			{
-				const auto lastError = Win32::GetLastError();
-				throw Error::Win32Error("InitializeSynchronizationBarrier() failed", lastError);
-			}
+			if (not Win32::InitializeSynchronizationBarrier(&m_barrier, m_totalThreads, m_spinCount))
+				throw Error::Win32Error(Win32::GetLastError(), "InitializeSynchronizationBarrier() failed");
 			m_isInitialized = true;
 		}
 
@@ -39,7 +34,7 @@ export namespace Boring32::Async
 
 		bool Enter(const Win32::DWORD flags)
 		{
-			if (!m_isInitialized)
+			if (not m_isInitialized)
 				throw Error::Boring32Error("Barrier is not initialised");
 			//https://docs.microsoft.com/en-us/windows/win32/api/synchapi/nf-synchapi-entersynchronizationbarrier
 			return Win32::EnterSynchronizationBarrier(&m_barrier, flags);

--- a/src/Boring32/Async/boring32-async_thread.ixx
+++ b/src/Boring32/Async/boring32-async_thread.ixx
@@ -63,10 +63,7 @@ export namespace Boring32::Async
 			if (not m_threadHandle)
 				throw Error::Boring32Error("No thread handle to terminate");
 			if (not Win32::TerminateThread(m_threadHandle.GetHandle(), exitCode))
-			{
-				const auto lastError = Win32::GetLastError();
-				throw Error::Win32Error("TerminateThread() failed", lastError);
-			}
+				throw Error::Win32Error(Win32::GetLastError(), "TerminateThread() failed");
 			m_status = ThreadStatus::Terminated;
 		}
 
@@ -78,10 +75,7 @@ export namespace Boring32::Async
 				throw Error::Boring32Error("Thread was not running when request to suspend occurred.");
 
 			if (not Win32::SuspendThread(m_threadHandle.GetHandle()))
-			{
-				const auto lastError = Win32::GetLastError();
-				throw Error::Win32Error("SuspendThread() failed", lastError);
-			}
+				throw Error::Win32Error(Win32::GetLastError(), "SuspendThread() failed");
 			m_status = ThreadStatus::Suspended;
 		}
 
@@ -91,8 +85,8 @@ export namespace Boring32::Async
 				throw Error::Boring32Error("No thread handle to resume");
 			if (m_status != ThreadStatus::Suspended)
 				throw Error::Boring32Error("Thread was not suspended when request to resume occurred.");
-			if (auto lastError = Win32::GetLastError(); not Win32::ResumeThread(m_threadHandle.GetHandle()))
-				throw Error::Win32Error("ResumeThread() failed", lastError);
+			if (not Win32::ResumeThread(m_threadHandle.GetHandle()))
+				throw Error::Win32Error(Win32::GetLastError(), "ResumeThread() failed");
 			m_status = ThreadStatus::Running;
 		}
 
@@ -108,8 +102,7 @@ export namespace Boring32::Async
 				return false;
 			if (waitResult == Win32::WaitAbandoned)
 				throw Error::Boring32Error("Wait was abandoned");
-			auto lastError = Win32::GetLastError();
-			throw Error::Win32Error("WaitForSingleObject() failed", lastError);
+			throw Error::Win32Error(Win32::GetLastError(), "WaitForSingleObject() failed");
 		}
 
 		virtual void Close()
@@ -145,8 +138,8 @@ export namespace Boring32::Async
 				throw Error::Boring32Error("No handle to thread; has the the thread been started or destroyed?");
 
 			Win32::DWORD exitCode;
-			if (auto lastError = Win32::GetLastError(); not Win32::GetExitCodeThread(m_threadHandle.GetHandle(), &exitCode))
-				throw Error::Win32Error("GetExitCodeThread() failed", lastError);
+			if (not Win32::GetExitCodeThread(m_threadHandle.GetHandle(), &exitCode))
+				throw Error::Win32Error(Win32::GetLastError(), "GetExitCodeThread() failed");
 			return exitCode;
 		}
 

--- a/src/Boring32/Async/boring32-async_timerqueue.ixx
+++ b/src/Boring32/Async/boring32-async_timerqueue.ixx
@@ -62,10 +62,7 @@ export namespace Boring32::Async
 
 			//https://docs.microsoft.com/en-us/windows/win32/api/threadpoollegacyapiset/nf-threadpoollegacyapiset-deletetimerqueueex
 			if (!Win32::DeleteTimerQueueEx(m_timer, argValue))
-			{
-				const auto lastError = Win32::GetLastError();
-				throw Error::Win32Error("DeleteTimerQueueEx() failed", lastError);
-			}
+				throw Error::Win32Error(Win32::GetLastError(), "DeleteTimerQueueEx() failed");
 			m_timer = nullptr;
 		}
 

--- a/src/Boring32/Async/boring32-async_timerqueuetimer.ixx
+++ b/src/Boring32/Async/boring32-async_timerqueuetimer.ixx
@@ -87,8 +87,8 @@ export namespace Boring32::Async
 				dueTime,
 				period
 			);
-			if (auto lastError = Win32::GetLastError(); not success)
-				throw Error::Win32Error("ChangeTimerQueueTimer() failed", lastError);
+			if (not success)
+				throw Error::Win32Error(Win32::GetLastError(), "ChangeTimerQueueTimer() failed");
 		}
 
 		virtual void Close()
@@ -101,8 +101,8 @@ export namespace Boring32::Async
 				m_timerQueueTimer,
 				m_completionEvent
 			);
-			if (auto lastError = Win32::GetLastError(); not succeeded)
-				throw Error::Win32Error("DeleteTimerQueueTimer() failed", lastError);
+			if (not succeeded)
+				throw Error::Win32Error(Win32::GetLastError(), "DeleteTimerQueueTimer() failed");
 			m_timerQueueTimer = nullptr;
 		}
 
@@ -149,8 +149,8 @@ export namespace Boring32::Async
 				m_period,
 				m_flags
 			);
-			if (auto lastError = Win32::GetLastError(); not succeeded)
-				throw Error::Win32Error("CreateTimerQueueTimer() failed", lastError);
+			if (not succeeded)
+				throw Error::Win32Error(Win32::GetLastError(), "CreateTimerQueueTimer() failed");
 		}
 
 		Win32::HANDLE m_timerQueue = nullptr;

--- a/src/Boring32/Async/boring32-async_waitableaddress.ixx
+++ b/src/Boring32/Async/boring32-async_waitableaddress.ixx
@@ -41,7 +41,7 @@ export namespace Boring32::Async
 			{
 				if (lastError == Win32::ErrorCodes::Timeout)
 					return false;
-				throw Error::Win32Error("WaitOnAddress() failed", lastError);
+				throw Error::Win32Error(lastError, "WaitOnAddress() failed");
 			}
 			return true;
 		}

--- a/src/Boring32/Compression/boring32-compression_compressor.ixx
+++ b/src/Boring32/Compression/boring32-compression_compressor.ixx
@@ -67,7 +67,7 @@ export namespace Boring32::Compression
 			if (not succeeded && lastError != Win32::ErrorCodes::InsufficientBuffer)
 			{
 				Error::ThrowNested(
-					Error::Win32Error("Compress() failed", lastError),
+					Error::Win32Error(lastError, "Compress() failed"),
 					CompressionError("An error occurred calculating the compressed size"));
 			}
 
@@ -99,10 +99,10 @@ export namespace Boring32::Compression
 				returnVal.size(),       //  Compressed Buffer size
 				&compressedBufferSize	//  Compressed Data size
 			);
-			if (auto lastError = Win32::GetLastError(); !succeeded)
+			if (not succeeded)
 			{
 				Error::ThrowNested(
-					Error::Win32Error("Compress() failed", lastError),
+					Error::Win32Error(Win32::GetLastError(), "Compress() failed"),
 					CompressionError("An error occurred compressing")
 				);
 			}
@@ -127,10 +127,10 @@ export namespace Boring32::Compression
 			if (not m_compressor)
 				throw CompressionError("Compressor handle is null");
 			// https://docs.microsoft.com/en-us/windows/win32/api/compressapi/nf-compressapi-resetcompressor
-			if (auto lastError = Win32::GetLastError(); not Win32::ResetCompressor(m_compressor.get()))
+			if (not Win32::ResetCompressor(m_compressor.get()))
 			{
 				Error::ThrowNested(
-					Error::Win32Error("ResetCompressor() failed", lastError),
+					Error::Win32Error(Win32::GetLastError(), "ResetCompressor() failed"),
 					CompressionError("An error occurred resetting the compressor")
 				);
 			}
@@ -148,10 +148,10 @@ export namespace Boring32::Compression
 				nullptr,		// AllocationRoutines
 				&handle			// CompressorHandle
 			);
-			if (auto lastError = Win32::GetLastError(); not succeeded)
+			if (not succeeded)
 			{
 				Error::ThrowNested(
-					Error::Win32Error("CreateCompressor() failed", lastError),
+					Error::Win32Error(Win32::GetLastError(), "CreateCompressor() failed"),
 					CompressionError("An error occurred creating the compressor")
 				);
 			}

--- a/src/Boring32/Compression/boring32-compression_decompressor.ixx
+++ b/src/Boring32/Compression/boring32-compression_decompressor.ixx
@@ -77,7 +77,7 @@ export namespace Boring32::Compression
 				return decompressedBufferSize;
 
 			Error::ThrowNested(
-				Error::Win32Error("Decompress() failed", lastError),
+				Error::Win32Error(lastError, "Decompress() failed"),
 				CompressionError("An error occurred while decompressing data")
 			);
 		}
@@ -101,10 +101,10 @@ export namespace Boring32::Compression
 				returnVal.size(),			//  Uncompressed buffer size
 				&decompressedBufferSize		//  Decompressed data size
 			);
-			if (auto lastError = Win32::GetLastError(); not succeeded)
+			if (not succeeded)
 			{
 				Error::ThrowNested(
-					Error::Win32Error("CreateDecompressor() failed", lastError),
+					Error::Win32Error(Win32::GetLastError(), "CreateDecompressor() failed"),
 					CompressionError("An error occurred creating the decompressor"));
 			}
 
@@ -121,10 +121,10 @@ export namespace Boring32::Compression
 			if (not m_decompressor)
 				throw CompressionError("Decompressor handle is null");
 			// https://docs.microsoft.com/en-us/windows/win32/api/compressapi/nf-compressapi-resetdecompressor
-			if (auto lastError = Win32::GetLastError(); not Win32::ResetDecompressor(m_decompressor.get()))
+			if (not Win32::ResetDecompressor(m_decompressor.get()))
 			{
 				Error::ThrowNested(
-					Error::Win32Error("ResetDecompressor() failed", lastError),
+					Error::Win32Error(Win32::GetLastError(), "ResetDecompressor() failed"),
 					CompressionError("An error occurred resetting the decompressor")
 				);
 			}
@@ -142,10 +142,10 @@ export namespace Boring32::Compression
 				nullptr,
 				&handle
 			);
-			if (auto lastError = Win32::GetLastError(); not succeeded)
+			if (not succeeded)
 			{
 				Error::ThrowNested(
-					Error::Win32Error("CreateDecompressor() failed", lastError),
+					Error::Win32Error(Win32::GetLastError(), "CreateDecompressor() failed"),
 					CompressionError("An error occurred creating the decompressor")
 				);
 			}

--- a/src/Boring32/Computer/boring32-computer_processinfo.ixx
+++ b/src/Boring32/Computer/boring32-computer_processinfo.ixx
@@ -37,8 +37,8 @@ export namespace Boring32::Computer
 
 			// https://docs.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-openprocess
 			m_processHandle = Win32::OpenProcess(Win32::ProcessQueryInformation, false, processId);
-			if (auto lastError = Win32::GetLastError(); not m_processHandle)
-				throw Error::Win32Error("OpenProcess() failed", lastError);
+			if (not m_processHandle)
+				throw Error::Win32Error(Win32::GetLastError(), "OpenProcess() failed");
 		}
 
 		ProcessTimes GetTimes() const
@@ -58,8 +58,8 @@ export namespace Boring32::Computer
 				&ftKernelTime,
 				&ftUserTime
 			);
-			if (auto lastError = GetLastError(); not success)
-				throw Error::Win32Error("GetProcessTimes() failed", lastError);
+			if (not success)
+				throw Error::Win32Error(GetLastError(), "GetProcessTimes() failed");
 
 			size_t startTime =
 				Win32::ULARGE_INTEGER{ ftCreationTime.dwLowDateTime, ftCreationTime.dwHighDateTime }.QuadPart;
@@ -93,8 +93,8 @@ export namespace Boring32::Computer
 				&path[0],
 				static_cast<Win32::DWORD>(path.size())
 			);
-			if (auto lastError = GetLastError(); not charactersCopied)
-				throw Error::Win32Error("K32GetModuleFileNameExW() failed", lastError);
+			if (not charactersCopied)
+				throw Error::Win32Error(GetLastError(), "K32GetModuleFileNameExW() failed");
 			return path.c_str();
 		}
 
@@ -104,8 +104,8 @@ export namespace Boring32::Computer
 				throw Error::Boring32Error("m_processHandle cannot be null");
 			// https://docs.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-getprocessid
 			Win32::DWORD id = Win32::GetProcessId(m_processHandle.GetHandle());
-			if (auto lastError = Win32::GetLastError(); not id)
-				throw Error::Win32Error("GetProcessId() failed", lastError);
+			if (not id)
+				throw Error::Win32Error(Win32::GetLastError(), "GetProcessId() failed");
 			return id;
 		}
 
@@ -117,8 +117,8 @@ export namespace Boring32::Computer
 			Win32::DWORD handleCount;
 			// https://docs.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-getprocesshandlecount
 			bool succeeded = Win32::GetProcessHandleCount(m_processHandle.GetHandle(), &handleCount);
-			if (auto lastError = Win32::GetLastError(); not succeeded)
-				throw Error::Win32Error("GetProcessHandleCount() failed", lastError);
+			if (not succeeded)
+				throw Error::Win32Error(Win32::GetLastError(), "GetProcessHandleCount() failed");
 			return handleCount;
 		}
 
@@ -129,9 +129,9 @@ export namespace Boring32::Computer
 
 			Win32::DWORD exitCode;
 			// https://docs.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-getexitcodeprocess
-			const bool succeeded = Win32::GetExitCodeProcess(m_processHandle.GetHandle(), &exitCode);
-			if (auto lastError = Win32::GetLastError(); not succeeded)
-				throw Error::Win32Error("GetExitCodeProcess() failed", lastError);
+			bool succeeded = Win32::GetExitCodeProcess(m_processHandle.GetHandle(), &exitCode);
+			if (not succeeded)
+				throw Error::Win32Error(Win32::GetLastError(), "GetExitCodeProcess() failed");
 			return exitCode;
 		}
 

--- a/src/Boring32/Crypto/boring32-crypto_certificate.ixx
+++ b/src/Boring32/Crypto/boring32-crypto_certificate.ixx
@@ -188,10 +188,7 @@ export namespace Boring32::Crypto
 				&m_certContext->pCertInfo->SubjectPublicKeyInfo
 			);
 			if (length == 0)
-			{
-				const auto lastError = Win32::GetLastError();
-				throw Error::Win32Error("CertGetPublicKeyLength() failed", lastError);
-			}
+				throw Error::Win32Error(Win32::GetLastError(), "CertGetPublicKeyLength() failed");
 			return length;
 		}
 
@@ -240,8 +237,8 @@ export namespace Boring32::Crypto
 				nullptr,
 				&sizeInBytes
 			);
-			if (auto lastError = Win32::GetLastError(); not succeeded)
-				throw Error::Win32Error("CertGetCertificateContextProperty() failed (1)", lastError);
+			if (not succeeded)
+				throw Error::Win32Error(Win32::GetLastError(), "CertGetCertificateContextProperty() failed (1)");
 
 			std::vector<std::byte> returnValue(sizeInBytes);
 			succeeded = Win32::CertGetCertificateContextProperty(
@@ -250,8 +247,8 @@ export namespace Boring32::Crypto
 				&returnValue[0],
 				&sizeInBytes
 			);
-			if (auto lastError = Win32::GetLastError(); not succeeded)
-				throw Error::Win32Error("CertGetCertificateContextProperty() failed (2)", lastError);
+			if (not succeeded)
+				throw Error::Win32Error(Win32::GetLastError(), "CertGetCertificateContextProperty() failed (2)");
 			returnValue.resize(sizeInBytes);
 
 			return returnValue;

--- a/src/Boring32/Crypto/boring32-crypto_securestring.ixx
+++ b/src/Boring32/Crypto/boring32-crypto_securestring.ixx
@@ -187,8 +187,8 @@ export namespace Boring32::Crypto
 				static_cast<Win32::DWORD>(m_protectedString.size() * sizeof(wchar_t)),
 				static_cast<Win32::DWORD>(m_encryptionType)
 			);
-			if (auto lastError = Win32::GetLastError(); not succeeded)
-				throw Error::Win32Error("CryptProtectMemory() failed", lastError);
+			if (not succeeded)
+				throw Error::Win32Error(Win32::GetLastError(), "CryptProtectMemory() failed");
 			m_isEncrypted = true;
 		}
 
@@ -204,8 +204,8 @@ export namespace Boring32::Crypto
 				static_cast<Win32::DWORD>(m_protectedString.size() * sizeof(wchar_t)),
 				static_cast<Win32::DWORD>(m_encryptionType)
 			);
-			if (auto lastError = Win32::GetLastError(); not succeeded)
-				throw Error::Win32Error("CryptUnprotectMemory() failed", lastError);
+			if (not succeeded)
+				throw Error::Win32Error(Win32::GetLastError(), "CryptUnprotectMemory() failed");
 			m_isEncrypted = false;
 		}
 

--- a/src/Boring32/Error/boring32-error_win32error.ixx
+++ b/src/Boring32/Error/boring32-error_win32error.ixx
@@ -5,7 +5,7 @@ import :error_functions;
 
 export namespace Boring32::Error
 {
-	struct Win32Error final : public Boring32Error
+	struct Win32Error final : Boring32Error
 	{
 		Win32Error(
 			const std::string& msg,
@@ -20,8 +20,8 @@ export namespace Boring32::Error
 		{ }
 
 		Win32Error(
-			const std::string& msg,
 			const unsigned long errorCode,
+			const std::string& msg,
 			const std::source_location location = std::source_location::current(),
 			const std::stacktrace & trace = std::stacktrace::current()
 		) : m_errorCode(errorCode), Boring32Error(Generate(msg, errorCode, location, trace))
@@ -29,8 +29,8 @@ export namespace Boring32::Error
 
 		template<typename...Args>
 		Win32Error(
-			const std::string& msg,
 			const unsigned long errorCode,
+			const std::string& msg,
 			const std::source_location location = std::source_location::current(),
 			const std::stacktrace& trace = std::stacktrace::current(),
 			const Args&...args
@@ -38,8 +38,8 @@ export namespace Boring32::Error
 		{ }
 
 		Win32Error(
-			const std::string& msg, 
 			const unsigned long errorCode,
+			const std::string& msg, 
 			const std::wstring& moduleName,
 			const std::source_location location = std::source_location::current(),
 			const std::stacktrace& trace = std::stacktrace::current()

--- a/src/Boring32/FileSystem/boring32-filesystem_file.ixx
+++ b/src/Boring32/FileSystem/boring32-filesystem_file.ixx
@@ -48,8 +48,8 @@ export namespace Boring32::FileSystem
 				Win32::FileAttributeNormal,			// dwFlagsAndAttributes
 				nullptr							// hTemplateFile
 			);
-			if (auto lastError = Win32::GetLastError(); m_fileHandle == Win32::InvalidHandleValue)
-				throw Error::Win32Error("CreateFileW() failed", lastError);
+			if (m_fileHandle == Win32::InvalidHandleValue)
+				throw Error::Win32Error(Win32::GetLastError(), "CreateFileW() failed");
 		}
 
 		std::wstring m_fileName;

--- a/src/Boring32/FileSystem/boring32-filesystem_functions.ixx
+++ b/src/Boring32/FileSystem/boring32-filesystem_functions.ixx
@@ -21,8 +21,8 @@ export namespace Boring32::FileSystem
 		Win32::DWORD verHandle = 0;
 		// https://docs.microsoft.com/en-us/windows/win32/api/winver/nf-winver-getfileversioninfosizew
 		Win32::DWORD verSize = Win32::GetFileVersionInfoSizeW(filePath.c_str(), &verHandle);
-		if (auto lastError = Win32::GetLastError(); not verSize)
-			throw Error::Win32Error("GetFileVersionInfoSizeW() failed", lastError);
+		if (not verSize)
+			throw Error::Win32Error(Win32::GetLastError(), "GetFileVersionInfoSizeW() failed");
 
 		std::vector<std::byte> verData(verSize);
 		// https://docs.microsoft.com/en-us/windows/win32/api/winver/nf-winver-getfileversioninfow
@@ -32,8 +32,8 @@ export namespace Boring32::FileSystem
 			verSize, 
 			&verData[0]
 		);
-		if (auto lastError = Win32::GetLastError(); not success)
-			throw Error::Win32Error("GetFileVersionInfoW() failed", lastError);
+		if (not success)
+			throw Error::Win32Error(Win32::GetLastError(), "GetFileVersionInfoW() failed");
 
 		unsigned size = 0;
 		std::byte* lpBuffer = nullptr; // Free when pBlock argument is freed
@@ -72,8 +72,8 @@ export namespace Boring32::FileSystem
 		if (path.empty())
 			throw Error::Boring32Error("path cannot be empty");
 		bool succeeded = Win32::CreateDirectoryW(path.c_str(), nullptr);
-		if (auto lastError = Win32::GetLastError(); not succeeded)
-			throw Error::Win32Error("CreateDirectoryW() failed", lastError);
+		if (not succeeded)
+			throw Error::Win32Error(Win32::GetLastError(), "CreateDirectoryW() failed");
 	}
 
 	void CreateFileDirectory(const std::wstring& path, const std::wstring& dacl)
@@ -84,22 +84,22 @@ export namespace Boring32::FileSystem
 			throw Error::Boring32Error("dacl cannot be empty");
 
 		void* sd = nullptr;
-		const bool succeeded = Win32::ConvertStringSecurityDescriptorToSecurityDescriptorW(
+		bool succeeded = Win32::ConvertStringSecurityDescriptorToSecurityDescriptorW(
 			dacl.c_str(),
 			Win32::SddlRevision1, // Must be SDDL_REVISION_1
 			&sd,
 			nullptr
 		);
-		if (auto lastError = Win32::GetLastError(); not succeeded)
-			throw Error::Win32Error("ConvertStringSecurityDescriptorToSecurityDescriptorW() failed", lastError);
+		if (not succeeded)
+			throw Error::Win32Error(Win32::GetLastError(), "ConvertStringSecurityDescriptorToSecurityDescriptorW() failed");
 		std::unique_ptr<void, void(*)(void*)> sdDeleter(sd, [](void* ptr) { Win32::LocalFree(ptr); });
 
 		Win32::SECURITY_ATTRIBUTES sa{
 			.nLength = sizeof(Win32::SECURITY_ATTRIBUTES),
 			.lpSecurityDescriptor = sd
 		};
-		if (auto lastError = GetLastError(); not Win32::CreateDirectoryW(path.c_str(), &sa))
-			throw Error::Win32Error("CreateDirectoryW() failed", lastError);
+		if (not Win32::CreateDirectoryW(path.c_str(), &sa))
+			throw Error::Win32Error(Win32::GetLastError(), "CreateDirectoryW() failed");
 	}
 
 	void MoveNamedFile(
@@ -114,8 +114,8 @@ export namespace Boring32::FileSystem
 			throw Error::Boring32Error("newFile cannot be empty");
 
 		// https://learn.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-movefileexw
-		if (auto lastError = Win32::GetLastError(); not Win32::MoveFileExW(oldFile.c_str(), newFile.c_str(), flags))
-			throw Error::Win32Error("MoveFileExW() failed", lastError);
+		if (not Win32::MoveFileExW(oldFile.c_str(), newFile.c_str(), flags))
+			throw Error::Win32Error(Win32::GetLastError(), "MoveFileExW() failed");
 	}
 
 	Win32::HANDLE FileCreate(
@@ -144,8 +144,8 @@ export namespace Boring32::FileSystem
 			flagsAndAttributes,			// dwFlagsAndAttributes
 			templateFile							// hTemplateFile
 		);
-		if (auto lastError = Win32::GetLastError(); fileHandle == Win32::InvalidHandleValue)
-			throw Error::Win32Error("CreateFileW() failed", lastError);
+		if (fileHandle == Win32::InvalidHandleValue)
+			throw Error::Win32Error(Win32::GetLastError(), "CreateFileW() failed");
 		return fileHandle;
 	}
 
@@ -178,8 +178,8 @@ export namespace Boring32::FileSystem
 			numberOfBytesWritten,
 			nullptr
 		);
-		if (auto lastError = Win32::GetLastError(); not success)
-			throw Error::Win32Error("WriteFile() failed", lastError);
+		if (not success)
+			throw Error::Win32Error(Win32::GetLastError(), "WriteFile() failed");
 	}
 
 	void WriteFile(
@@ -207,8 +207,8 @@ export namespace Boring32::FileSystem
 			nullptr,
 			const_cast<Win32::OVERLAPPED*>(&overlapped)
 		);
-		if (auto lastError = Win32::GetLastError(); not success)
-			throw Error::Win32Error("WriteFile() failed", lastError);
+		if (not success)
+			throw Error::Win32Error(Win32::GetLastError(), "WriteFile() failed");
 	}
 
 	void ReadFile(
@@ -234,7 +234,7 @@ export namespace Boring32::FileSystem
 			&lpNumberOfBytesRead,
 			nullptr
 		);
-		if (auto lastError = Win32::GetLastError(); not success)
-			throw Error::Win32Error("ReadFile() failed", lastError);
+		if (not success)
+			throw Error::Win32Error(Win32::GetLastError(), "ReadFile() failed");
 	}
 }

--- a/src/Boring32/IO/boring32-io_completionport.ixx
+++ b/src/Boring32/IO/boring32-io_completionport.ixx
@@ -23,8 +23,8 @@ export namespace Boring32::IO
 		{
 			if (not device)
 				throw Error::Boring32Error("device cannot be null");
-			if (auto lastError = Win32::GetLastError(); not Win32::CreateIoCompletionPort(device, m_completionPort.GetHandle(), completionKey, 0))
-				throw Error::Win32Error("CreateIoCompletionPort() failed", lastError);
+			if (not Win32::CreateIoCompletionPort(device, m_completionPort.GetHandle(), completionKey, 0))
+				throw Error::Win32Error(Win32::GetLastError(), "CreateIoCompletionPort() failed");
 		}
 
 		Win32::HANDLE GetHandle() const noexcept
@@ -47,10 +47,10 @@ export namespace Boring32::IO
 				Win32::Infinite
 			);
 
-			if (Win32::DWORD lastError = Win32::GetLastError(); not success)
+			if (not success)
 			{
-				if (not overlapped and lastError != Win32::ErrorCodes::AbandonedWait0)
-					throw Error::Win32Error("GetQueuedCompletionStatus() failed", lastError);
+				if (auto lastError = Win32::GetLastError(); not overlapped and lastError != Win32::ErrorCodes::AbandonedWait0)
+					throw Error::Win32Error(lastError, "GetQueuedCompletionStatus() failed");
 				else {}
 				// Dequeued a completion packet for a failed I/O operation.
 				// Not really clear what we should do here.

--- a/src/Boring32/IPC/boring32-ipc_anonymouspipe.ixx
+++ b/src/Boring32/IPC/boring32-ipc_anonymouspipe.ixx
@@ -22,14 +22,14 @@ export namespace Boring32::IPC
 				.nLength = sizeof(Win32::SECURITY_ATTRIBUTES),
 				.bInheritHandle = inheritable
 			};
-			const bool success = Win32::CreatePipe(
+			bool success = Win32::CreatePipe(
 				&m_readHandle,
 				&m_writeHandle,
 				&secAttrs,
 				size
 			);
-			if (auto lastError = Win32::GetLastError(); not success)
-				throw Error::Win32Error("Failed creating anonymous pipe: CreatePipe() failed.", lastError);
+			if (not success)
+				throw Error::Win32Error(Win32::GetLastError(), "Failed creating anonymous pipe: CreatePipe() failed.");
 		}
 
 		AnonymousPipe(Win32::DWORD size, Win32::HANDLE readHandle, Win32::HANDLE writeHandle) 
@@ -54,8 +54,8 @@ export namespace Boring32::IPC
 				&bytesWritten,
 				nullptr
 			);
-			if (auto lastError = Win32::GetLastError(); not success)
-				throw Error::Win32Error("Write operation failed.", lastError);
+			if (not success)
+				throw Error::Win32Error(Win32::GetLastError(), "Write operation failed.");
 		}
 
 		virtual std::wstring Read()
@@ -73,8 +73,8 @@ export namespace Boring32::IPC
 				&bytesRead,
 				nullptr
 			);
-			if (auto lastError = Win32::GetLastError(); !success)
-				throw Error::Win32Error("ReadFile() failed", lastError);
+			if (not success)
+				throw Error::Win32Error(Win32::GetLastError(), "ReadFile() failed");
 
 			std::erase_if(msg, [](wchar_t c) { return c == '\0'; });
 			return msg;
@@ -112,8 +112,8 @@ export namespace Boring32::IPC
 				nullptr,
 				nullptr
 			);
-			if (auto lastError = Win32::GetLastError(); not succeeded)
-				throw Error::Win32Error("SetNamedPipeHandleState() failed.", lastError);
+			if (not succeeded)
+				throw Error::Win32Error(Win32::GetLastError(), "SetNamedPipeHandleState() failed.");
 		}
 
 		virtual Win32::HANDLE GetRead() const noexcept
@@ -152,8 +152,8 @@ export namespace Boring32::IPC
 					&charactersInPipe,
 					nullptr
 				);
-				if (auto lastError = Win32::GetLastError(); not success)
-					throw Error::Win32Error("PeekNamedPipe() failed", lastError);
+				if (not success)
+					throw Error::Win32Error(Win32::GetLastError(), "PeekNamedPipe() failed");
 				charactersInPipe /= sizeof(wchar_t);
 			}
 

--- a/src/Boring32/IPC/boring32-ipc_blockingnamedpipeclient.ixx
+++ b/src/Boring32/IPC/boring32-ipc_blockingnamedpipeclient.ixx
@@ -77,8 +77,8 @@ export namespace Boring32::IPC
 				&bytesWritten,      // bytes written 
 				nullptr				// not overlapped 
 			);
-			if (auto lastError = Win32::GetLastError(); not successfulWrite)
-				throw Error::Win32Error("Failed to write to client pipe", lastError);
+			if (not successfulWrite)
+				throw Error::Win32Error(Win32::GetLastError(), "Failed to write to client pipe");
 		}
 
 		std::vector<std::byte> InternalRead()
@@ -106,7 +106,7 @@ export namespace Boring32::IPC
 
 				const Win32::DWORD lastError = Win32::GetLastError();
 				if (auto lastError = GetLastError(); not successfulRead and lastError != Win32::ErrorCodes::MoreData)
-					throw Error::Win32Error("Failed to read from pipe", lastError);
+					throw Error::Win32Error(lastError, "Failed to read from pipe");
 				if (lastError == Win32::ErrorCodes::MoreData)
 					dataBuffer.resize(dataBuffer.size() + blockSize);
 				continueReading = !successfulRead;

--- a/src/Boring32/IPC/boring32-ipc_mailslotserver.ixx
+++ b/src/Boring32/IPC/boring32-ipc_mailslotserver.ixx
@@ -15,8 +15,8 @@ export namespace Boring32::IPC
 
 			// https://docs.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-createmailslotw
 			m_handle = Win32::CreateMailslotW(m_name.c_str(), m_maxMessageSize, m_readTimeoutMs, nullptr);
-			if (auto lastError = Win32::GetLastError(); not m_handle)
-				throw Error::Win32Error("CreateMailslotW() failed", lastError);
+			if (not m_handle)
+				throw Error::Win32Error(Win32::GetLastError(), "CreateMailslotW() failed");
 		}
 
 		void Close() noexcept

--- a/src/Boring32/IPC/boring32-ipc_namedpipeserverbase.ixx
+++ b/src/Boring32/IPC/boring32-ipc_namedpipeserverbase.ixx
@@ -95,10 +95,7 @@ export namespace Boring32::IPC
 			if (!m_pipe)
 				throw Error::Boring32Error("No pipe to flush");
 			if (!Win32::FlushFileBuffers(m_pipe.GetHandle()))
-			{
-				const auto lastError = Win32::GetLastError();
-				throw Error::Win32Error("Flush() failed", lastError);
-			}
+				throw Error::Win32Error(Win32::GetLastError(), "Flush() failed");
 		}
 
 		virtual RAII::Win32Handle& GetInternalHandle()
@@ -151,10 +148,7 @@ export namespace Boring32::IPC
 			if (!m_pipe)
 				throw Error::Boring32Error("pipe is nullptr");
 			if (!Win32::CancelIo(m_pipe.GetHandle()))
-			{
-				const auto lastError = GetLastError();
-				throw Error::Win32Error("CancelIo() failed", lastError);
-			}
+				throw Error::Win32Error(Win32::GetLastError(), "CancelIo() failed");
 		}
 
 		virtual bool CancelCurrentThreadIo(std::nothrow_t) noexcept 
@@ -173,10 +167,7 @@ export namespace Boring32::IPC
 			if (!m_pipe)
 				throw Error::Boring32Error("pipe is nullptr");
 			if (!Win32::CancelIoEx(m_pipe.GetHandle(), overlapped))
-			{
-				const auto lastError = Win32::GetLastError();
-				throw Error::Win32Error("CancelIo() failed", lastError);
-			}
+				throw Error::Win32Error(Win32::GetLastError(), "CancelIo() failed");
 		}
 
 		virtual bool CancelCurrentProcessIo(Win32::OVERLAPPED* overlapped, std::nothrow_t) noexcept 
@@ -202,17 +193,14 @@ export namespace Boring32::IPC
 			};
 			if (!m_sid.empty())
 			{
-				const bool converted = Win32::ConvertStringSecurityDescriptorToSecurityDescriptorW(
+				bool converted = Win32::ConvertStringSecurityDescriptorToSecurityDescriptorW(
 					m_sid.c_str(),
 					Win32::SddlRevision1,
 					&sa.lpSecurityDescriptor,
 					nullptr
 				);
 				if (!converted)
-				{
-					const auto lastError = Win32::GetLastError();
-					throw Error::Win32Error("Failed to convert security descriptor", lastError);
-				}
+					throw Error::Win32Error(Win32::GetLastError(), "Failed to convert security descriptor");
 			}
 
 			// https://docs.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-createnamedpipea
@@ -229,10 +217,7 @@ export namespace Boring32::IPC
 			if (!m_sid.empty())
 				Win32::LocalFree(sa.lpSecurityDescriptor);
 			if (!m_pipe)
-			{
-				const auto lastError = Win32::GetLastError();
-				throw Error::Win32Error("Failed to create named pipe", lastError);
-			}
+				throw Error::Win32Error(Win32::GetLastError(), "Failed to create named pipe");
 		}
 
 		virtual void Copy(const NamedPipeServerBase& other)
@@ -276,10 +261,7 @@ export namespace Boring32::IPC
 			if (!succeeded)
 			{
 				if (throwOnError)
-				{
-					const auto lastError = Win32::GetLastError();
-					throw Error::Win32Error("PeekNamedPipe() failed", lastError);
-				}
+					throw Error::Win32Error(Win32::GetLastError(), "PeekNamedPipe() failed");
 				return false;
 			}
 

--- a/src/Boring32/IPC/boring32-ipc_overlappednamedpipeclient.ixx
+++ b/src/Boring32/IPC/boring32-ipc_overlappednamedpipeclient.ixx
@@ -61,7 +61,7 @@ export namespace Boring32::IPC
 				oio.GetOverlapped());							// overlapped 
 			oio.LastError(Win32::GetLastError());
 			if (not succeeded and oio.LastError() != Win32::ErrorCodes::IoPending)
-				throw Error::Win32Error("WriteFile() failed", oio.LastError());
+				throw Error::Win32Error(oio.LastError(), "WriteFile() failed");
 		}
 
 		void InternalRead(const Win32::DWORD noOfCharacters, Async::OverlappedIo& oio)
@@ -82,7 +82,7 @@ export namespace Boring32::IPC
 
 			if (not succeeded)
 				if (oio.LastError() != Win32::ErrorCodes::IoPending and oio.LastError() != Win32::ErrorCodes::MoreData)
-					throw Error::Win32Error("ReadFile() failed", oio.LastError());
+					throw Error::Win32Error(oio.LastError(), "ReadFile() failed");
 		}
 	};
 }

--- a/src/Boring32/IPC/boring32-ipc_overlappednamedpipeserver.ixx
+++ b/src/Boring32/IPC/boring32-ipc_overlappednamedpipeserver.ixx
@@ -91,7 +91,7 @@ export namespace Boring32::IPC
 			bool succeeded = Win32::ConnectNamedPipe(m_pipe.GetHandle(), oio.GetOverlapped());
 			oio.LastError(GetLastError());
 			if (not succeeded and oio.LastError() != Win32::ErrorCodes::IoPending)
-				throw Error::Win32Error("ConnectNamedPipe() failed", oio.LastError());
+				throw Error::Win32Error(oio.LastError(), "ConnectNamedPipe() failed");
 
 			/*
 			HANDLE out = nullptr;
@@ -164,7 +164,7 @@ export namespace Boring32::IPC
 			);
 			oio.LastError(Win32::GetLastError());
 			if (not succeeded and oio.LastError() != Win32::ErrorCodes::IoPending)
-				throw Error::Win32Error("WriteFile() failed", oio.LastError());
+				throw Error::Win32Error(oio.LastError(), "WriteFile() failed");
 		}
 
 		void InternalRead(const Win32::DWORD noOfCharacters, Async::OverlappedIo& oio)
@@ -186,7 +186,7 @@ export namespace Boring32::IPC
 
 			oio.LastError(Win32::GetLastError());
 			if (oio.LastError() != Win32::ErrorCodes::IoPending and oio.LastError() != Win32::ErrorCodes::MoreData)
-				throw Error::Win32Error("ReadFile() failed", oio.LastError());
+				throw Error::Win32Error(oio.LastError(), "ReadFile() failed");
 		}
 	};
 }

--- a/src/Boring32/MSI/boring32-msi_database.ixx
+++ b/src/Boring32/MSI/boring32-msi_database.ixx
@@ -115,13 +115,9 @@ export namespace Boring32::MSI
 			Close();
 
 			// https://learn.microsoft.com/en-us/windows/win32/api/msiquery/nf-msiquery-msiopendatabasew
-			unsigned status = Win32::MsiOpenDatabaseW(
-				m_path.c_str(),
-				LPCWSTR(m_mode),
-				&m_handle
-			);
+			unsigned status = Win32::MsiOpenDatabaseW(m_path.c_str(), Win32::LPCWSTR(m_mode), &m_handle);
 			if (status != Win32::ErrorCodes::Success)
-				throw Error::Win32Error("MsiOpenDatabaseW() failed", status);
+				throw Error::Win32Error(status, "MsiOpenDatabaseW() failed");
 		}
 
 		std::wstring GetProperty(std::wstring_view propertyName) const
@@ -143,18 +139,18 @@ export namespace Boring32::MSI
 				&hView
 			);
 			if (status != Win32::ErrorCodes::Success)
-				throw Error::Win32Error("MsiDatabaseOpenView() failed", status);
+				throw Error::Win32Error(status, "MsiDatabaseOpenView() failed");
 				
 			// https://learn.microsoft.com/en-us/windows/win32/api/msiquery/nf-msiquery-msiviewexecute
 			status = Win32::MsiViewExecute(hView, 0);
 			if (status != Win32::ErrorCodes::Success)
-				throw Error::Win32Error("MsiViewExecute() failed", status);
+				throw Error::Win32Error(status, "MsiViewExecute() failed");
 				
 			Win32::PMSIHANDLE hViewFetch;
 			// https://learn.microsoft.com/en-us/windows/win32/api/msiquery/nf-msiquery-msiviewfetch
 			status = Win32::MsiViewFetch(hView, &hViewFetch);
 			if (status != Win32::ErrorCodes::Success)
-				throw Error::Win32Error("MsiViewFetch() failed", status);
+				throw Error::Win32Error(status, "MsiViewFetch() failed");
 
 			Win32::DWORD charCount = 0;
 			// https://learn.microsoft.com/en-us/windows/win32/api/msiquery/nf-msiquery-msirecordgetstringw
@@ -166,7 +162,7 @@ export namespace Boring32::MSI
 				&charCount
 			);
 			if (status != Win32::ErrorCodes::MoreData)
-				throw Error::Win32Error("MsiRecordGetString() failed", status);
+				throw Error::Win32Error(status, "MsiRecordGetString() failed");
 
 			charCount++; // must increment to include null-terminator
 			returnValue.resize(charCount);
@@ -177,7 +173,7 @@ export namespace Boring32::MSI
 				&charCount
 			);
 			if (status != Win32::ErrorCodes::Success)
-				throw Error::Win32Error("MsiRecordGetString() failed", status);
+				throw Error::Win32Error(status, "MsiRecordGetString() failed");
 
 			returnValue.resize(charCount);
 			return returnValue;

--- a/src/Boring32/MSI/boring32-msi_functions.ixx
+++ b/src/Boring32/MSI/boring32-msi_functions.ixx
@@ -32,7 +32,7 @@ export namespace Boring32::MSI
 			if (status == Win32::ErrorCodes::NoMoreItems)
 				return returnValue;
 			if (status != Win32::ErrorCodes::Success)
-				throw Error::Win32Error("MsiEnumProductsExW() failed", status);
+				throw Error::Win32Error(status, "MsiEnumProductsExW() failed");
 
 			returnValue.emplace_back(std::move(productCode));
 			index++;
@@ -66,7 +66,7 @@ export namespace Boring32::MSI
 		if (status == Win32::ErrorCodes::UnknownProperty)
 			return {};
 		if (status != Win32::ErrorCodes::Success)
-			throw Error::Win32Error("MsiGetProductInfoExW() failed [1]", status);
+			throw Error::Win32Error(status, "MsiGetProductInfoExW() failed [1]");
 
 		// The returned character count excludes the null terminator,
 		// but this is required, so we bump the value.
@@ -83,7 +83,7 @@ export namespace Boring32::MSI
 		if (status == Win32::ErrorCodes::UnknownProperty)
 			return {};
 		if (status != Win32::ErrorCodes::Success)
-			throw Error::Win32Error("MsiGetProductInfoExW() failed [2]", status);
+			throw Error::Win32Error(status, "MsiGetProductInfoExW() failed [2]");
 
 		returnValue.resize(characters);
 		if (propertyFound)

--- a/src/Boring32/MSI/boring32-msi_package.ixx
+++ b/src/Boring32/MSI/boring32-msi_package.ixx
@@ -40,7 +40,7 @@ export namespace Boring32::MSI
 				&m_handle
 			);
 			if (status != Win32::ErrorCodes::Success)
-				throw Error::Win32Error("MsiOpenPackageW() failed", status);
+				throw Error::Win32Error(status, "MsiOpenPackageW() failed");
 		}
 
 		std::wstring m_path;

--- a/src/Boring32/MSI/boring32-msi_product.ixx
+++ b/src/Boring32/MSI/boring32-msi_product.ixx
@@ -12,7 +12,7 @@ export namespace Boring32::MSI
 			// https://learn.microsoft.com/en-us/windows/win32/api/msi/nf-msi-msiisproductelevatedw
 			unsigned status = Win32::MsiIsProductElevatedW(path.c_str(), &isElevated);
 			if (status != Win32::ErrorCodes::Success)
-				throw Error::Win32Error("MsiIsProductElevatedW() failed", status);
+				throw Error::Win32Error(status, "MsiIsProductElevatedW() failed");
 			return isElevated;
 		}
 	};

--- a/src/Boring32/Memory/boring32-memory-heap.ixx
+++ b/src/Boring32/Memory/boring32-memory-heap.ixx
@@ -38,8 +38,8 @@ export namespace Boring32::Memory
 		{
 			// https://learn.microsoft.com/en-us/windows/win32/api/heapapi/nf-heapapi-heapcreate
 			m_heap = Win32::HeapCreate(options, initialSize, maxSize);
-			if (auto lastError = Win32::GetLastError(); not m_heap)
-				throw Error::Win32Error("HeapCreate() failed", lastError);
+			if (not m_heap)
+				throw Error::Win32Error(Win32::GetLastError(), "HeapCreate() failed");
 		}
 
 		void Destroy()
@@ -57,7 +57,7 @@ export namespace Boring32::Memory
 			// https://learn.microsoft.com/en-us/windows/win32/api/heapapi/nf-heapapi-heapcompact
 			size_t size = Win32::HeapCompact(m_heap, 0);
 			if (auto lastError = Win32::GetLastError(); lastError != Win32::ErrorCodes::NoError)
-				throw Error::Win32Error("HeapCompact() failed", lastError);
+				throw Error::Win32Error(lastError, "HeapCompact() failed");
 			return size;
 		}
 
@@ -74,23 +74,23 @@ export namespace Boring32::Memory
 		void Lock()
 		{
 			// https://learn.microsoft.com/en-us/windows/win32/api/heapapi/nf-heapapi-heaplock
-			if (auto lastError = Win32::GetLastError(); not Win32::HeapLock(m_heap))
-				throw Error::Win32Error("HeapLock() failed", lastError);
+			if (not Win32::HeapLock(m_heap))
+				throw Error::Win32Error(Win32::GetLastError(), "HeapLock() failed");
 		}
 			
 		void Unlock()
 		{
 			// https://learn.microsoft.com/en-us/windows/win32/api/heapapi/nf-heapapi-heapunlock
-			if (auto lastError = Win32::GetLastError(); not Win32::HeapUnlock(m_heap))
-				throw Error::Win32Error("HeapUnlock() failed", lastError);
+			if (not Win32::HeapUnlock(m_heap))
+				throw Error::Win32Error(Win32::GetLastError(), "HeapUnlock() failed");
 		}
 
 		[[nodiscard]] void* New(size_t bytes, Win32::DWORD options = 0)
 		{
 			// https://learn.microsoft.com/en-us/windows/win32/api/heapapi/nf-heapapi-heapalloc
 			void* allocation = Win32::HeapAlloc(m_heap, options, bytes);
-			if (auto lastError = Win32::GetLastError(); not allocation)
-				throw Error::Win32Error("HeapAlloc() failed", lastError);
+			if (not allocation)
+				throw Error::Win32Error(Win32::GetLastError(), "HeapAlloc() failed");
 			return allocation;
 		}
 
@@ -124,8 +124,8 @@ export namespace Boring32::Memory
 		void Delete(void* ptr, Win32::DWORD options = 0)
 		{
 			// https://learn.microsoft.com/en-us/windows/win32/api/heapapi/nf-heapapi-heapfree
-			if (auto lastError = Win32::GetLastError(); ptr and not Win32::HeapFree(m_heap, options, ptr))
-				throw Error::Win32Error("HeapFree() failed", lastError);
+			if (ptr and not Win32::HeapFree(m_heap, options, ptr))
+				throw Error::Win32Error(Win32::GetLastError(), "HeapFree() failed");
 		}
 
 		// https://learn.microsoft.com/en-us/windows/win32/api/heapapi/nf-heapapi-getprocessheap

--- a/src/Boring32/Native/boring32-native_ntdll.ixx
+++ b/src/Boring32/Native/boring32-native_ntdll.ixx
@@ -22,24 +22,24 @@ export namespace Boring32::Native
 		void Map()
 		{
 			Win32::HMODULE ntdll = Win32::GetModuleHandleW(L"ntdll.dll");
-			if (auto lastError = Win32::GetLastError(); not ntdll)
-				throw Error::Win32Error("GetModuleHandleW() failed", lastError);
+			if (not ntdll)
+				throw Error::Win32Error(Win32::GetLastError(), "GetModuleHandleW() failed");
 
 			m_mapViewOfSection = (MapViewOfSection)Win32::GetProcAddress(ntdll, "NtMapViewOfSection");
-			if (auto lastError = Win32::GetLastError(); not m_mapViewOfSection)
-				throw Error::Win32Error("GetProcAddress() failed", lastError);
+			if (not m_mapViewOfSection)
+				throw Error::Win32Error(Win32::GetLastError(), "GetProcAddress() failed");
 
 			m_querySystemInformation = (QuerySystemInformation)Win32::GetProcAddress(ntdll, "NtQuerySystemInformation");
-			if (auto lastError = Win32::GetLastError(); not m_querySystemInformation)
-				throw Error::Win32Error("GetProcAddress() failed", lastError);
+			if (not m_querySystemInformation)
+				throw Error::Win32Error(Win32::GetLastError(), "GetProcAddress() failed");
 
 			m_duplicateObject = (DuplicateObject)Win32::GetProcAddress(ntdll, "NtDuplicateObject");
-			if (auto lastError = Win32::GetLastError(); not m_duplicateObject)
-				throw Error::Win32Error("GetProcAddress() failed", lastError);
+			if (not m_duplicateObject)
+				throw Error::Win32Error(Win32::GetLastError(), "GetProcAddress() failed");
 
 			m_queryObject = (QueryObject)Win32::GetProcAddress(ntdll, "NtQueryObject");
-			if (auto lastError = Win32::GetLastError(); not m_queryObject)
-				throw Error::Win32Error("GetProcAddress() failed", lastError);
+			if (not m_queryObject)
+				throw Error::Win32Error(Win32::GetLastError(), "GetProcAddress() failed");
 		}
 
 		MapViewOfSection m_mapViewOfSection;

--- a/src/Boring32/Networking/boring32-networking_api.ixx
+++ b/src/Boring32/Networking/boring32-networking_api.ixx
@@ -24,10 +24,7 @@ export namespace Boring32::Networking
 			// bufferSizeBytes will give the correct buffer size in this case,
 			// and will be used to resize the buffer in the next iteration.
 			if (status != Win32::ErrorCodes::BufferOverflow && status != Win32::ErrorCodes::Success)
-			{
-				const auto lastError = Win32::GetLastError();
-				throw Error::Win32Error("GetAdaptersAddresses() failed", lastError);
-			}
+				throw Error::Win32Error(Win32::GetLastError(), "GetAdaptersAddresses() failed");
 		}
 		buffer.resize(bufferSizeBytes);
 		// This is safe to do because the heap pointer is moved to the calling site,

--- a/src/Boring32/Process/boring32-process_dynamiclinklibrary.ixx
+++ b/src/Boring32/Process/boring32-process_dynamiclinklibrary.ixx
@@ -66,8 +66,7 @@ export namespace Boring32::Process
 			if (void* ptr = Win32::GetProcAddress(m_libraryHandle, symbolName.c_str()))
 				return ptr;
 
-			const auto lastError = Win32::GetLastError();
-			throw Error::Win32Error(std::format("Failed to resolve symbol: {}", symbolName), lastError);
+			throw Error::Win32Error(Win32::GetLastError(), std::format("Failed to resolve symbol: {}", symbolName));
 		}
 
 		void* Resolve(const std::string& symbolName, const std::nothrow_t&) noexcept
@@ -129,10 +128,7 @@ export namespace Boring32::Process
 
 			m_libraryHandle = Win32::LoadLibraryW(m_path.c_str());
 			if (not m_libraryHandle)
-			{
-				const auto lastError = Win32::GetLastError();
-				throw Error::Win32Error("failed to load library", lastError);
-			}
+				throw Error::Win32Error(Win32::GetLastError(), "failed to load library");
 		}
 
 		bool InternalLoad(const std::nothrow_t&) noexcept 

--- a/src/Boring32/RAII/boring32-raii_win32handle.ixx
+++ b/src/Boring32/RAII/boring32-raii_win32handle.ixx
@@ -121,10 +121,7 @@ export namespace Boring32::RAII
 			if (not IsValidValue())
 				throw Error::Boring32Error("handle is null or invalid.");
 			if (not Win32::SetHandleInformation(*m_handle, Win32::HandleFlagInherit, isInheritable))
-			{
-				const auto lastError = Win32::GetLastError();
-				throw Error::Win32Error("SetHandleInformation() failed", lastError);
-			}
+				throw Error::Win32Error(Win32::GetLastError(), "SetHandleInformation() failed");
 		}
 
 		Win32::HANDLE Detach() noexcept
@@ -163,10 +160,7 @@ export namespace Boring32::RAII
 
 			Win32::DWORD flags = 0;
 			if (not Win32::GetHandleInformation(handle, &flags))
-			{
-				const Win32::DWORD lastError = GetLastError();
-				throw Error::Win32Error("GetHandleInformation() failed", lastError);
-			}
+				throw Error::Win32Error(GetLastError(), "GetHandleInformation() failed");
 			return flags & Win32::HandleFlagInherit;
 		}
 
@@ -187,8 +181,8 @@ export namespace Boring32::RAII
 				isInheritable,
 				Win32::DuplicateSameAccess
 			);
-			if (auto lastError = GetLastError(); not succeeded)
-				throw Error::Win32Error("DuplicateHandle() failed", lastError);
+			if (not succeeded)
+				throw Error::Win32Error(Win32::GetLastError(), "DuplicateHandle() failed");
 
 			return duplicateHandle;
 		}

--- a/src/Boring32/Registry/boring32-registry_functions.ixx
+++ b/src/Boring32/Registry/boring32-registry_functions.ixx
@@ -33,7 +33,7 @@ export namespace Boring32::Registry
 			&sizeInBytes
 		);
 		if (status != Win32::ErrorCodes::Success)
-			throw Error::Win32Error("RegGetValueW() failed", status);
+			throw Error::Win32Error(status, "RegGetValueW() failed");
 		return out;
 	}
 
@@ -59,10 +59,7 @@ export namespace Boring32::Registry
 			&sizeInBytes
 		);
 		if (statusCode != Win32::ErrorCodes::Success)
-			throw Error::Win32Error(
-				"RegGetValueW() failed (1)",
-				statusCode
-			);
+			throw Error::Win32Error(statusCode, "RegGetValueW() failed (1)");
 
 		out.resize(sizeInBytes / sizeof(wchar_t), '\0');
 		statusCode = Win32::Winreg::RegGetValueW(
@@ -75,10 +72,7 @@ export namespace Boring32::Registry
 			&sizeInBytes
 		);
 		if (statusCode != Win32::ErrorCodes::Success)
-			throw Error::Win32Error(
-				"RegGetValueW() failed (2)",
-				statusCode
-			);
+			throw Error::Win32Error(statusCode, "RegGetValueW() failed (2)");
 
 		out.resize(sizeInBytes / sizeof(wchar_t));
 		// Exclude terminating null
@@ -112,7 +106,7 @@ export namespace Boring32::Registry
 		if (!key)
 			throw Error::Boring32Error("key is nullptr");
 
-		const Win32::LSTATUS status = Win32::Winreg::RegSetValueExW(
+		Win32::LSTATUS status = Win32::Winreg::RegSetValueExW(
 			key,
 			valueName.c_str(),
 			0,
@@ -121,7 +115,7 @@ export namespace Boring32::Registry
 			sizeof(value)
 		);
 		if (status != Win32::ErrorCodes::Success)
-			throw Error::Win32Error("RegSetValueExW() failed", status);
+			throw Error::Win32Error(status, "RegSetValueExW() failed");
 	}
 
 	// This should probably be integrated into RegistryKey to enable safety checks
@@ -151,31 +145,19 @@ export namespace Boring32::Registry
 			throw Error::Boring32Error("Parent cannot be nullptr");
 
 		// https://docs.microsoft.com/en-us/windows/win32/api/shlwapi/nf-shlwapi-shdeletekeyw
-		const Win32::LSTATUS status = Win32::SHDeleteKeyW(
-			parent,
-			subkey.c_str()
-		);
+		Win32::LSTATUS status = Win32::SHDeleteKeyW(parent, subkey.c_str());
 		if (status != Win32::ErrorCodes::Success)
-		{
-			const auto lastError = Win32::GetLastError();
-			throw Error::Win32Error("SHDeleteKeyW() failed", lastError);
-		}
+			throw Error::Win32Error(Win32::GetLastError(), "SHDeleteKeyW() failed");
 	}
 
 	void DeleteSubkeys(const Win32::Winreg::HKEY parent, const std::wstring& subkey)
 	{
-		if (parent == nullptr)
+		if (not parent)
 			throw Error::Boring32Error("parent cannot be nullptr");
 
 		// https://docs.microsoft.com/en-us/windows/win32/api/winreg/nf-winreg-regdeletetreew
-		const LSTATUS status = Win32::Winreg::RegDeleteTreeW(
-			parent,
-			subkey.c_str()
-		);
+		Win32::LSTATUS status = Win32::Winreg::RegDeleteTreeW(parent, subkey.c_str());
 		if (status != Win32::ErrorCodes::Success)
-		{
-			const auto lastError = Win32::GetLastError();
-			throw Error::Win32Error("RegDeleteTreeW() failed", lastError);
-		}
+			throw Error::Win32Error(Win32::GetLastError(), "RegDeleteTreeW() failed");
 	}
 }

--- a/src/Boring32/Registry/boring32-registry_key.ixx
+++ b/src/Boring32/Registry/boring32-registry_key.ixx
@@ -119,7 +119,7 @@ export namespace Boring32::Registry
 				(Win32::DWORD)((value.size() + 1) * sizeof(wchar_t))
 			);
 			if (status != Win32::ErrorCodes::Success)
-				throw Error::Win32Error("RegSetValueExW() failed", status);
+				throw Error::Win32Error(status, "RegSetValueExW() failed");
 		}
 
 		void WriteValue(
@@ -150,7 +150,7 @@ export namespace Boring32::Registry
 				Win32::Winreg::_REG_LATEST_FORMAT
 			);
 			if (status != Win32::ErrorCodes::Success)
-				throw Error::Win32Error("RegSaveKeyExW() failed", status);
+				throw Error::Win32Error(status, "RegSaveKeyExW() failed");
 		}
 
 		std::vector<KeyValues> GetValues()
@@ -189,9 +189,7 @@ export namespace Boring32::Registry
 					break;
 				}
 				if (status != Win32::ErrorCodes::Success)
-				{
-					throw Error::Win32Error("RegEnumValueW() failed.", status);
-				}
+					throw Error::Win32Error(status, "RegEnumValueW() failed.");
 				valueToAdd.Name = std::wstring(
 					valueNameBuffer.begin(),
 					valueNameBuffer.begin() + valueNameCharacterLength
@@ -221,10 +219,7 @@ export namespace Boring32::Registry
 				nullptr
 			);
 			if (status)
-				throw Error::Win32Error(
-					"Failed to open registry key",
-					status
-				);
+				throw Error::Win32Error(status, "Failed to open registry key");
 			return subkeys;
 		}
 
@@ -252,7 +247,7 @@ export namespace Boring32::Registry
 		void InternalOpen(const Win32::Winreg::HKEY superKey, const std::wstring& subkey)
 		{
 			Win32::Winreg::HKEY key = nullptr;
-			const Win32::LSTATUS status = Win32::Winreg::RegOpenKeyExW(
+			Win32::LSTATUS status = Win32::Winreg::RegOpenKeyExW(
 				superKey,
 				subkey.c_str(),
 				0,
@@ -260,10 +255,7 @@ export namespace Boring32::Registry
 				&key
 			);
 			if (status != Win32::ErrorCodes::Success)
-				throw Error::Win32Error(
-					"Failed to open registry key", 
-					status
-				);
+				throw Error::Win32Error(status, "Failed to open registry key");
 			m_key = CreateRegKeyPtr(key);
 		}
 

--- a/src/Boring32/Security/boring32-security_impersonationcontext.ixx
+++ b/src/Boring32/Security/boring32-security_impersonationcontext.ixx
@@ -5,67 +5,60 @@ import boring32.shared;
 export namespace Boring32::Security
 {
 	// https://docs.microsoft.com/en-us/windows/win32/secauthz/client-impersonation
-	class ImpersonationContext
+	struct ImpersonationContext final
 	{
-		public:
-			virtual ~ImpersonationContext()
-			{
-				Close();
-			}
-			ImpersonationContext(const ImpersonationContext&) = delete;
-			ImpersonationContext(ImpersonationContext&& other) noexcept
-			{
-				Move(other);
-			}
-			ImpersonationContext(Win32::HANDLE const token)
-			{
-				if (!token || token == Win32::InvalidHandleValue)
-					throw Error::Boring32Error("token is invalid");
-				// https://docs.microsoft.com/en-us/windows/win32/api/securitybaseapi/nf-securitybaseapi-impersonateloggedonuser
-				if (!Win32::ImpersonateLoggedOnUser(token))
-				{
-					const auto lastError = Win32::GetLastError();
-					throw Error::Win32Error("ImpersonateLoggedOnUser() failed", lastError);
-				}
-			}
+		~ImpersonationContext()
+		{
+			Close();
+		}
+		ImpersonationContext(const ImpersonationContext&) = delete;
+		ImpersonationContext(ImpersonationContext&& other) noexcept
+		{
+			Move(other);
+		}
+		ImpersonationContext(Win32::HANDLE const token)
+		{
+			if (not token or token == Win32::InvalidHandleValue)
+				throw Error::Boring32Error("token is invalid");
+			// https://docs.microsoft.com/en-us/windows/win32/api/securitybaseapi/nf-securitybaseapi-impersonateloggedonuser
+			if (not Win32::ImpersonateLoggedOnUser(token))
+				throw Error::Win32Error(Win32::GetLastError(), "ImpersonateLoggedOnUser() failed");
+		}
 
-		public:
-			virtual ImpersonationContext& operator=(const ImpersonationContext&) = delete;
-			virtual ImpersonationContext& operator=(ImpersonationContext&&) noexcept = delete;
+		ImpersonationContext& operator=(const ImpersonationContext&) = delete;
+		ImpersonationContext& operator=(ImpersonationContext&&) noexcept = delete;
 
-		public:
-			virtual bool Close()
+		bool Close()
+		{
+			if (m_registryHive)
 			{
-				if (m_registryHive)
-				{
-					Win32::Winreg::RegCloseKey(m_registryHive);
-					m_registryHive = nullptr;
-				}
-				// https://docs.microsoft.com/en-us/windows/win32/api/securitybaseapi/nf-securitybaseapi-reverttoself
-				return Win32::RevertToSelf();
+				Win32::Winreg::RegCloseKey(m_registryHive);
+				m_registryHive = nullptr;
 			}
+			// https://docs.microsoft.com/en-us/windows/win32/api/securitybaseapi/nf-securitybaseapi-reverttoself
+			return Win32::RevertToSelf();
+		}
 
-			virtual Win32::Winreg::HKEY GetUserRegistry()
+		Win32::Winreg::HKEY GetUserRegistry()
+		{
+			if (not m_registryHive)
 			{
-				if (m_registryHive == nullptr)
-				{
-					// https://docs.microsoft.com/en-us/windows/win32/api/winreg/nf-winreg-regopencurrentuser
-					Win32::LSTATUS status = Win32::Winreg::RegOpenCurrentUser(Win32::_KEY_READ, &m_registryHive);
-					if (status != Win32::ErrorCodes::Success)
-						throw Error::NTStatusError("RegOpenCurrentUser() failed", status);
-				}
-				return m_registryHive;
+				// https://docs.microsoft.com/en-us/windows/win32/api/winreg/nf-winreg-regopencurrentuser
+				Win32::LSTATUS status = Win32::Winreg::RegOpenCurrentUser(Win32::_KEY_READ, &m_registryHive);
+				if (status != Win32::ErrorCodes::Success)
+					throw Error::NTStatusError("RegOpenCurrentUser() failed", status);
 			}
+			return m_registryHive;
+		}
 
-		protected:
-			virtual ImpersonationContext& Move(ImpersonationContext& other) noexcept
-			{
-				m_registryHive = other.m_registryHive;
-				other.m_registryHive = nullptr;
-				return *this;
-			}
+		private:
+		ImpersonationContext& Move(ImpersonationContext& other) noexcept
+		{
+			m_registryHive = other.m_registryHive;
+			other.m_registryHive = nullptr;
+			return *this;
+		}
 
-		protected:
-			Win32::Winreg::HKEY m_registryHive = nullptr;
+		Win32::Winreg::HKEY m_registryHive = nullptr;
 	};
 }

--- a/src/Boring32/Security/boring32-security_level.ixx
+++ b/src/Boring32/Security/boring32-security_level.ixx
@@ -40,10 +40,7 @@ export namespace Boring32::Security
 					0
 				);
 				if (not successful)
-				{
-					const auto lastError = Win32::GetLastError();
-					throw Error::Win32Error("SaferComputeTokenFromLevel() failed", lastError);
-				}
+					throw Error::Win32Error(Win32::GetLastError(), "SaferComputeTokenFromLevel() failed");
 				return out;
 			}
 
@@ -65,10 +62,7 @@ export namespace Boring32::Security
 						0
 					);
 					if (not successful)
-					{
-						const auto lastError = Win32::GetLastError();
-						throw Error::Win32Error("SaferCreateLevel() failed", lastError);
-					}
+						throw Error::Win32Error(Win32::GetLastError(), "SaferCreateLevel() failed");
 					return handle;
 				}(m_scope, m_level, m_flags);
 	};

--- a/src/Boring32/Security/boring32-security_privatenamespace.ixx
+++ b/src/Boring32/Security/boring32-security_privatenamespace.ixx
@@ -95,10 +95,7 @@ export namespace Boring32::Security
 			{
 				m_boundaryDescriptor = Win32::CreateBoundaryDescriptorW(m_boundaryName.c_str(), 0);
 				if (!m_boundaryDescriptor)
-				{
-					const auto lastError = Win32::GetLastError();
-					throw Error::Win32Error("Failed to create boundary descriptor", lastError);
-				}
+					throw Error::Win32Error(Win32::GetLastError(), "Failed to create boundary descriptor");
 
 				Win32::BYTE localAdminSID[Win32::_SECURITY_MAX_SID_SIZE];
 				Win32::DWORD cbSID = sizeof(localAdminSID);
@@ -108,16 +105,10 @@ export namespace Boring32::Security
 					localAdminSID,
 					&cbSID);
 				if (!sidCreated)
-				{
-					const auto lastError = Win32::GetLastError();
-					throw Error::Win32Error("Failed to create SID", lastError);
-				}
+					throw Error::Win32Error(Win32::GetLastError(), "Failed to create SID");
 				bool sidAdded = Win32::AddSIDToBoundaryDescriptor(&m_boundaryDescriptor, localAdminSID);
 				if (!sidAdded)
-				{
-					const auto lastError = Win32::GetLastError();
-					throw Error::Win32Error("Failed to add SID to boundary", lastError);
-				}
+					throw Error::Win32Error(Win32::GetLastError(), "Failed to add SID to boundary");
 
 				if (create)
 				{
@@ -134,10 +125,7 @@ export namespace Boring32::Security
 						nullptr
 					);
 					if (!converted)
-					{
-						const auto lastError = Win32::GetLastError();
-						throw Error::Win32Error("Failed to convert security descriptor", lastError);
-					}
+						throw Error::Win32Error(Win32::GetLastError(), "Failed to convert security descriptor");
 					RAII::LocalHeapUniquePtr<void> securityDescriptor(sa.lpSecurityDescriptor);
 
 					m_namespace = Win32::CreatePrivateNamespaceW(
@@ -150,10 +138,7 @@ export namespace Boring32::Security
 					m_namespace = Win32::OpenPrivateNamespaceW(m_boundaryDescriptor, m_namespaceName.c_str());
 
 				if (!m_namespace)
-				{
-					const auto lastError = Win32::GetLastError();
-					throw Error::Win32Error("Failed to create private namespace", lastError);
-				}
+					throw Error::Win32Error(Win32::GetLastError(), "Failed to create private namespace");
 			}
 			catch (...)
 			{

--- a/src/Boring32/Security/boring32-security_securitydescriptor.ixx
+++ b/src/Boring32/Security/boring32-security_securitydescriptor.ixx
@@ -65,9 +65,9 @@ export namespace Boring32::Security
 		{
 			SecurityDescriptor::Control c{ 0 };
 			// https://learn.microsoft.com/en-us/windows/win32/api/securitybaseapi/nf-securitybaseapi-getsecuritydescriptorcontrol
-			const bool success = Win32::GetSecurityDescriptorControl(m_descriptor.get(), &c.Control, &c.Revision);
-			if (auto lastError = Win32::GetLastError(); not success)
-				throw Error::Win32Error("GetSecurityDescriptorControl() failed", lastError);
+			bool success = Win32::GetSecurityDescriptorControl(m_descriptor.get(), &c.Control, &c.Revision);
+			if (not success)
+				throw Error::Win32Error(Win32::GetLastError(), "GetSecurityDescriptorControl() failed");
 			return c;
 		}
 
@@ -83,8 +83,8 @@ export namespace Boring32::Security
 				&sd,
 				nullptr
 			);
-			if (auto lastError = Win32::GetLastError(); not succeeded)
-				throw Error::Win32Error("ConvertStringSecurityDescriptorToSecurityDescriptorW() failed", lastError);
+			if (not succeeded)
+				throw Error::Win32Error(Win32::GetLastError(), "ConvertStringSecurityDescriptorToSecurityDescriptorW() failed");
 			m_descriptor = RAII::LocalHeapUniquePtr<Win32::SECURITY_DESCRIPTOR>(reinterpret_cast<Win32::SECURITY_DESCRIPTOR*>(sd));
 		}
 

--- a/src/Boring32/Security/boring32-security_securityidentifier.ixx
+++ b/src/Boring32/Security/boring32-security_securityidentifier.ixx
@@ -60,12 +60,8 @@ export namespace Boring32::Security
 			{
 				Win32::LPWSTR string = nullptr;
 				// https://docs.microsoft.com/en-us/windows/win32/api/sddl/nf-sddl-convertsidtostringsidw
-				const bool succeeded = Win32::ConvertSidToStringSidW(m_sid, &string);
-				if (!succeeded)
-				{
-					const auto lastError = Win32::GetLastError();
-					throw Error::Win32Error("ConvertSidToStringSidW() failed", lastError);
-				}
+				if (not Win32::ConvertSidToStringSidW(m_sid, &string))
+					throw Error::Win32Error(Win32::GetLastError(), "ConvertSidToStringSidW() failed");
 				RAII::LocalHeapUniquePtr<wchar_t> ptr(string);
 				return string;
 			}
@@ -106,8 +102,7 @@ export namespace Boring32::Security
 				if (Win32::PSID_IDENTIFIER_AUTHORITY identifier = Win32::GetSidIdentifierAuthority(m_sid))
 					return *identifier;
 
-				const auto lastError = Win32::GetLastError();
-				throw Error::Win32Error("GetSidIdentifierAuthority() failed", lastError);
+				throw Error::Win32Error(Win32::GetLastError(), "GetSidIdentifierAuthority() failed");
 			}
 
 			Win32::DWORD GetSubAuthority(const Win32::DWORD index) const
@@ -118,8 +113,7 @@ export namespace Boring32::Security
 				if (Win32::PDWORD returnVal = Win32::GetSidSubAuthority(m_sid, index))
 					return *returnVal;
 
-				const auto lastError = Win32::GetLastError();
-				throw Error::Win32Error("GetSidSubAuthority() failed", lastError);
+				throw Error::Win32Error(Win32::GetLastError(),"GetSidSubAuthority() failed");
 			}
 
 			std::vector<Win32::DWORD> GetAllSubAuthorities() const
@@ -162,10 +156,7 @@ export namespace Boring32::Security
 					throw Error::Boring32Error("sidString cannot be empty");
 				// https://docs.microsoft.com/en-us/windows/win32/api/sddl/nf-sddl-convertstringsidtosidw
 				if (!Win32::ConvertStringSidToSidW(sidString.c_str(), &m_sid))
-				{
-					const auto lastError = Win32::GetLastError();
-					throw Error::Win32Error("ConvertStringSidToSidW() failed", lastError);
-				}
+					throw Error::Win32Error(Win32::GetLastError(), "ConvertStringSidToSidW() failed");
 			}
 
 			void Create(
@@ -192,10 +183,7 @@ export namespace Boring32::Security
 					&m_sid
 				);
 				if (!succeeded)
-				{
-					const auto lastError = Win32::GetLastError();
-					throw Error::Win32Error("Failed to initialise SID", lastError);
-				}
+					throw Error::Win32Error(Win32::GetLastError(), "Failed to initialise SID");
 			}
 			
 		private:

--- a/src/Boring32/Security/boring32-security_token.ixx
+++ b/src/Boring32/Security/boring32-security_token.ixx
@@ -69,10 +69,7 @@ export namespace Boring32::Security
 					&m_token
 				);
 				if (!succeeded)
-				{
-					const auto lastError = Win32::GetLastError();
-					throw Error::Win32Error("DuplicateTokenEx() failed", lastError);
-				}
+					throw Error::Win32Error(Win32::GetLastError(), "DuplicateTokenEx() failed");
 			}
 			
 		public:
@@ -117,10 +114,7 @@ export namespace Boring32::Security
 						&m_token
 					);
 					if (!succeeded)
-					{
-						const auto lastError = Win32::GetLastError();
-						throw Error::Win32Error("DuplicateTokenEx() failed", lastError);
-					}
+						throw Error::Win32Error(Win32::GetLastError(), "DuplicateTokenEx() failed");
 				}
 
 				return *this;

--- a/src/Boring32/Services/boring32-services_functions.ixx
+++ b/src/Boring32/Services/boring32-services_functions.ixx
@@ -7,41 +7,32 @@ export namespace Boring32::Services
 	[[nodiscard]] Win32::SC_HANDLE OpenServiceControlManager(const Win32::DWORD desiredAccess)
 	{
 		// https://docs.microsoft.com/en-us/windows/win32/api/winsvc/nf-winsvc-openscmanagerw
-		const SC_HANDLE scmHandle = Win32::OpenSCManagerW(
-			nullptr,
-			Win32::_SERVICES_ACTIVE_DATABASE,
-			desiredAccess // https://docs.microsoft.com/en-us/windows/win32/services/service-security-and-access-rights
-		);
-		if (!scmHandle)
-		{
-			const auto lastError = Win32::GetLastError();
-			throw Error::Win32Error("OpenSCManagerW() failed", lastError);
-		}
+		// https://docs.microsoft.com/en-us/windows/win32/services/service-security-and-access-rights
+		SC_HANDLE scmHandle = Win32::OpenSCManagerW(nullptr, Win32::_SERVICES_ACTIVE_DATABASE, desiredAccess);
+		if (not scmHandle)
+			throw Error::Win32Error(Win32::GetLastError(), "OpenSCManagerW() failed");
 
 		return scmHandle;
 	}
 
 	[[nodiscard]] Win32::SERVICE_STATUS_PROCESS GetServiceStatus(const Win32::SC_HANDLE serviceHandle)
 	{
-		if (!serviceHandle)
+		if (not serviceHandle)
 			throw Boring32::Error::Boring32Error("Service handle cannot be null");
 
 		Win32::DWORD bytesNeeded = 0;
 		// https://docs.microsoft.com/en-us/windows/win32/api/winsvc/ns-winsvc-service_status_process
 		Win32::SERVICE_STATUS_PROCESS serviceStatus{ 0 };
 		// https://docs.microsoft.com/en-us/windows/win32/api/winsvc/nf-winsvc-queryservicestatusex
-		const bool succeeded = Win32::QueryServiceStatusEx(
+		bool succeeded = Win32::QueryServiceStatusEx(
 			serviceHandle,
 			Win32::SC_STATUS_TYPE::SC_STATUS_PROCESS_INFO, // this is the only one defined
 			reinterpret_cast<BYTE*>(&serviceStatus),
 			sizeof(serviceStatus),
 			&bytesNeeded
 		);
-		if (!succeeded)
-		{
-			const auto lastError = Win32::GetLastError();
-			throw Error::Win32Error("QueryServiceStatusEx() failed", lastError);
-		}
+		if (not succeeded)
+			throw Error::Win32Error(Win32::GetLastError(), "QueryServiceStatusEx() failed");
 
 		return serviceStatus;
 	}
@@ -52,20 +43,17 @@ export namespace Boring32::Services
 		const Win32::DWORD desiredAccess
 	)
 	{
-		if (!scmHandle)
+		if (not scmHandle)
 			throw Boring32::Error::Boring32Error("SCM handle cannot be null");
 
 		// https://docs.microsoft.com/en-us/windows/win32/api/winsvc/nf-winsvc-openservicew
-		const Win32::SC_HANDLE serviceHandle = Win32::OpenServiceW(
+		Win32::SC_HANDLE serviceHandle = Win32::OpenServiceW(
 			scmHandle,
 			serviceName.c_str(),
 			desiredAccess // https://docs.microsoft.com/en-us/windows/win32/services/service-security-and-access-rights
 		);
-		if (!serviceHandle)
-		{
-			const auto lastError = Win32::GetLastError();
-			throw Error::Win32Error("OpenServiceW() failed", lastError);
-		}
+		if (not serviceHandle)
+			throw Error::Win32Error(Win32::GetLastError(), "OpenServiceW() failed");
 
 		return serviceHandle;
 	}

--- a/src/Boring32/Services/boring32-services_service.ixx
+++ b/src/Boring32/Services/boring32-services_service.ixx
@@ -38,8 +38,8 @@ export namespace Boring32::Services
 				static_cast<Win32::DWORD>(argv.size()),
 				&argv[0]
 			);
-			if (auto lastError = Win32::GetLastError(); not succeeded)
-				throw Error::Win32Error("StartServiceW() failed", lastError);
+			if (not succeeded)
+				throw Error::Win32Error(Win32::GetLastError(), "StartServiceW() failed");
 		}
 
 		void Stop()
@@ -59,16 +59,16 @@ export namespace Boring32::Services
 				Win32::_SERVICE_CONTROL_STATUS_REASON_INFO,
 				&params
 			);
-			if (auto lastError = Win32::GetLastError(); not succeeded)
-				throw Error::Win32Error("ControlServiceExW() failed", lastError);
+			if (not succeeded)
+				throw Error::Win32Error(Win32::GetLastError(),"ControlServiceExW() failed");
 		}
 
 		void Delete()
 		{
 			if (not m_service)
 				throw Error::Boring32Error("m_service is nullptr");
-			if (auto lastError = Win32::GetLastError(); not Win32::DeleteService(m_service.get()))
-				throw Error::Win32Error("service parameter cannot be null", lastError);
+			if (not Win32::DeleteService(m_service.get()))
+				throw Error::Win32Error(Win32::GetLastError(), "service parameter cannot be null");
 			m_service = nullptr;
 		}
 
@@ -96,8 +96,8 @@ export namespace Boring32::Services
 				sizeof(status),
 				&bufSize
 			);
-			if (auto lastError = Win32::GetLastError(); not succeeded)
-				throw Error::Win32Error("QueryServiceStatusEx() failed", lastError);
+			if (not succeeded)
+				throw Error::Win32Error(Win32::GetLastError(), "QueryServiceStatusEx() failed");
 			return status.dwCurrentState == Win32::_SERVICE_RUNNING;
 		}
 			
@@ -122,8 +122,8 @@ export namespace Boring32::Services
 				Win32::_SERVICE_CONTROL_STATUS_REASON_INFO,
 				&params
 			);
-			if (auto lastError = Win32::GetLastError(); not succeeded)
-				throw Error::Win32Error("ControlServiceExW() failed", lastError);
+			if (not succeeded)
+				throw Error::Win32Error(Win32::GetLastError(), "ControlServiceExW() failed");
 		}
 
 		private:
@@ -140,7 +140,7 @@ export namespace Boring32::Services
 				&bytesNeeded
 			);
 			if (auto lastError = Win32::GetLastError(); lastError != Win32::ErrorCodes::InsufficientBuffer)
-				throw Error::Win32Error("QueryServiceConfigW() failed", lastError);
+				throw Error::Win32Error(lastError, "QueryServiceConfigW() failed");
 
 			std::vector<std::byte> buffer(bytesNeeded);
 			succeeded = QueryServiceConfigW(
@@ -149,8 +149,8 @@ export namespace Boring32::Services
 				static_cast<Win32::DWORD>(buffer.size()),
 				&bytesNeeded
 			);
-			if (auto lastError = Win32::GetLastError(); not succeeded)
-				throw Error::Win32Error("QueryServiceConfigW() failed", lastError);
+			if (not succeeded)
+				throw Error::Win32Error(Win32::GetLastError(), "QueryServiceConfigW() failed");
 			return buffer;
 		}
 

--- a/src/Boring32/Services/boring32-services_servicecontrolmanager.ixx
+++ b/src/Boring32/Services/boring32-services_servicecontrolmanager.ixx
@@ -49,8 +49,8 @@ export namespace Boring32::Services
 				name.c_str(),
 				desiredAccess
 			);
-			if (auto lastError = Win32::GetLastError(); not serviceHandle)
-				throw Error::Win32Error("OpenServiceW() failed", lastError);
+			if (not serviceHandle)
+				throw Error::Win32Error(Win32::GetLastError(), "OpenServiceW() failed");
 			return { CreateSharedPtr(serviceHandle) };
 		}
 
@@ -68,8 +68,8 @@ export namespace Boring32::Services
 				nullptr,        // ServicesActive database 
 				desiredAccess   // full access rights
 			);
-			if (auto lastError = Win32::GetLastError(); not schSCManager)
-				throw Error::Win32Error("OpenSCManagerW() failed", lastError);
+			if (not schSCManager)
+				throw Error::Win32Error(Win32::GetLastError(), "OpenSCManagerW() failed");
 			m_scm = CreateSharedPtr(schSCManager);
 		}
 

--- a/src/Boring32/Strings/boring32-strings.ixx
+++ b/src/Boring32/Strings/boring32-strings.ixx
@@ -26,10 +26,7 @@ export namespace Boring32::Strings
 			nullptr											// lpUsedDefaultChar
 		);
 		if (sizeInBytes == 0)
-		{
-			const auto lastError = Win32::GetLastError();
-			throw Error::Win32Error("WideCharToMultiByte() [1] failed", lastError);
-		}
+			throw Error::Win32Error(Win32::GetLastError(), "WideCharToMultiByte() [1] failed");
 
 		std::string strTo(sizeInBytes / sizeof(char), '\0');
 		const int status = WideCharToMultiByte(
@@ -43,10 +40,7 @@ export namespace Boring32::Strings
 			nullptr											// lpUsedDefaultChar
 		);
 		if (status == 0)
-		{
-			const auto lastError = Win32::GetLastError();
-			throw Error::Win32Error("WideCharToMultiByte() [2] failed", lastError);
-		}
+			throw Error::Win32Error(Win32::GetLastError(), "WideCharToMultiByte() [2] failed");
 
 		return strTo;
 	}
@@ -58,7 +52,7 @@ export namespace Boring32::Strings
 
 		// https://docs.microsoft.com/en-us/windows/win32/api/stringapiset/nf-stringapiset-multibytetowidechar
 		// Returns the size in characters, this differs from WideCharToMultiByte, which returns the size in bytes
-		const int sizeInCharacters = Win32::MultiByteToWideChar(
+		int sizeInCharacters = Win32::MultiByteToWideChar(
 			Win32::CpUtf8,									// CodePage
 			0,											// dwFlags
 			&str[0],									// lpMultiByteStr
@@ -67,13 +61,10 @@ export namespace Boring32::Strings
 			0											// cchWideChar
 		);
 		if (sizeInCharacters == 0)
-		{
-			const auto lastError = Win32::GetLastError();
-			throw Error::Win32Error("MultiByteToWideChar() [1] failed", lastError);
-		}
+			throw Error::Win32Error(Win32::GetLastError(), "MultiByteToWideChar() [1] failed");
 
 		std::wstring wstrTo(sizeInCharacters, '\0');
-		const int status = Win32::MultiByteToWideChar(
+		int status = Win32::MultiByteToWideChar(
 			Win32::CpUtf8,									// CodePage
 			0,											// dwFlags
 			&str[0],									// lpMultiByteStr
@@ -82,10 +73,7 @@ export namespace Boring32::Strings
 			static_cast<int>(wstrTo.size())				// cchWideChar
 		);
 		if (status == 0)
-		{
-			const auto lastError = Win32::GetLastError();
-			throw Error::Win32Error("MultiByteToWideChar() [2] failed", lastError);
-		}
+			throw Error::Win32Error(Win32::GetLastError(), "MultiByteToWideChar() [2] failed");
 
 		return wstrTo;
 	}
@@ -94,17 +82,11 @@ export namespace Boring32::Strings
 	decltype(auto) To(Concepts::AnyString auto&& from)
 	{
 		if constexpr (Concepts::OneOf<decltype(from), TString&, const TString&>)
-		{
 			return from;
-		}
 		else if constexpr (std::is_constructible_v<TString, decltype(from)>)
-		{
 			return TString{ std::forward<decltype(from)>(from) };
-		}
 		else
-		{
 			return ConvertString(from);
-		}
 	}
 
 	/* old implementation
@@ -468,10 +450,7 @@ export namespace Boring32::Strings
 			0
 		);
 		if (result == 0)
-		{
-			const auto lastError = Win32::GetLastError();
-			throw Error::Win32Error("LCMapStringEx() failed.", lastError);
-		}
+			throw Error::Win32Error(Win32::GetLastError(), "LCMapStringEx() failed.");
 
 		std::wstring destination(result, '\0');
 		result = Win32::i18n::LCMapStringEx(
@@ -486,10 +465,7 @@ export namespace Boring32::Strings
 			0
 		);
 		if (result == 0)
-		{
-			const auto lastError = Win32::GetLastError();
-			throw Error::Win32Error("LCMapStringEx() failed.", lastError);
-		}
+			throw Error::Win32Error(Win32::GetLastError(), "LCMapStringEx() failed.");
 
 		return destination;
 	}

--- a/src/Boring32/Time/boring32-time_datetime.ixx
+++ b/src/Boring32/Time/boring32-time_datetime.ixx
@@ -16,10 +16,7 @@ export namespace Boring32::Time
 		DateTime(const Win32::SYSTEMTIME& st)
 		{
 			if (!Win32::SystemTimeToFileTime(&st, &m_ft))
-			{
-				const auto lastError = Win32::GetLastError();
-				throw Error::Win32Error("SystemTimeToFileTime() failed", lastError);
-			}
+				throw Error::Win32Error(Win32::GetLastError(), "SystemTimeToFileTime() failed");
 		}
 
 		DateTime(const Win32::FILETIME& ft)
@@ -59,10 +56,7 @@ export namespace Boring32::Time
 			Win32::SYSTEMTIME st;
 			// https://docs.microsoft.com/en-us/windows/win32/api/timezoneapi/nf-timezoneapi-filetimetosystemtime
 			if (!Win32::FileTimeToSystemTime(&m_ft, &st))
-			{
-				const auto lastError = Win32::GetLastError();
-				throw Error::Win32Error("FileTimeToSystemTime() failed", lastError);
-			}
+				throw Error::Win32Error(Win32::GetLastError(), "FileTimeToSystemTime() failed");
 			return st;
 		}
 

--- a/src/Boring32/Time/boring32-time_functions.ixx
+++ b/src/Boring32/Time/boring32-time_functions.ixx
@@ -6,18 +6,15 @@ export namespace Boring32::Time
 {
 	Win32::SYSTEMTIME LargeIntegerTimeToSystemTime(const Win32::LARGE_INTEGER& li)
 	{
-		const Win32::FILETIME ft{
+		Win32::FILETIME ft{
 			.dwLowDateTime = li.LowPart,
 			.dwHighDateTime = static_cast<Win32::DWORD>(li.HighPart)
 		};
 
 		Win32::SYSTEMTIME st;
 		// https://docs.microsoft.com/en-us/windows/win32/api/timezoneapi/nf-timezoneapi-filetimetosystemtime
-		if (!Win32::FileTimeToSystemTime(&ft, &st))
-		{
-			const auto lastError = Win32::GetLastError();
-			throw Error::Win32Error("FileTimeToSystemTime() failed", lastError);
-		}
+		if (not Win32::FileTimeToSystemTime(&ft, &st))
+			throw Error::Win32Error(Win32::GetLastError(), "FileTimeToSystemTime() failed");
 		return st;
 	}
 
@@ -36,11 +33,8 @@ export namespace Boring32::Time
 			dateStringLength,
 			nullptr
 		);
-		if (!status)
-		{
-			const auto lastError = Win32::GetLastError();
-			throw Error::Win32Error("GetDateFormatEx() failed", lastError);
-		}
+		if (not status)
+			throw Error::Win32Error(Win32::GetLastError(), "GetDateFormatEx() failed");
 
 		// Format time buffer
 		constexpr unsigned timeStringLength = 9;
@@ -54,20 +48,14 @@ export namespace Boring32::Time
 			timeString,
 			timeStringLength
 		);
-		if (!status)
-		{
-			const auto lastError = Win32::GetLastError();
-			throw Error::Win32Error("GetTimeFormatEx() failed", lastError);
-		}
+		if (not status)
+			throw Error::Win32Error(Win32::GetLastError(), "GetTimeFormatEx() failed");
 
 		Win32::TIME_ZONE_INFORMATION tzi;
 		// https://docs.microsoft.com/en-us/windows/win32/api/datetimeapi/nf-datetimeapi-gettimeformatex
-		const Win32::DWORD tziStatus = Win32::GetTimeZoneInformation(&tzi);
+		Win32::DWORD tziStatus = Win32::GetTimeZoneInformation(&tzi);
 		if (tziStatus == Win32::TimeZoneIdInvalid)
-		{
-			const auto lastError = Win32::GetLastError();
-			throw Error::Win32Error("GetTimeZoneInformation() failed", lastError);
-		}
+			throw Error::Win32Error(Win32::GetLastError(), "GetTimeZoneInformation() failed");
 
 		const long actualBias = tzi.Bias * -1; // should we do this?
 		return std::vformat(L"{}-{}.{}{:+}", std::make_wformat_args(dateString, timeString, st.wMilliseconds, actualBias));
@@ -130,11 +118,8 @@ export namespace Boring32::Time
 			nullptr,
 			0
 		);
-		if (!charactersNeeded)
-		{
-			const auto lastError = Win32::GetLastError();
-			throw Error::Win32Error("GetTimeFormatEx() failed", lastError);
-		}
+		if (not charactersNeeded)
+			throw Error::Win32Error(Win32::GetLastError(), "GetTimeFormatEx() failed");
 
 		std::wstring returnVal(charactersNeeded, '\0');
 		charactersNeeded = Win32::GetTimeFormatEx(
@@ -145,11 +130,8 @@ export namespace Boring32::Time
 			&returnVal[0],
 			static_cast<int>(returnVal.size())
 		);
-		if (!charactersNeeded)
-		{
-			const auto lastError = Win32::GetLastError();
-			throw Error::Win32Error("GetTimeFormatEx() failed", lastError);
-		}
+		if (not charactersNeeded)
+			throw Error::Win32Error(Win32::GetLastError(), "GetTimeFormatEx() failed");
 
 		return returnVal.c_str(); // remove any trailing null
 	}
@@ -171,11 +153,8 @@ export namespace Boring32::Time
 			0,
 			nullptr
 		);
-		if (!charactersRequired)
-		{
-			const auto lastError = Win32::GetLastError();
-			throw Error::Win32Error("GetDateFormatEx() failed", lastError);
-		}
+		if (not charactersRequired)
+			throw Error::Win32Error(Win32::GetLastError(), "GetDateFormatEx() failed");
 
 		std::wstring formattedString(charactersRequired, '\0');
 		charactersRequired = Win32::GetDateFormatEx(
@@ -187,11 +166,8 @@ export namespace Boring32::Time
 			static_cast<int>(formattedString.size()),
 			nullptr
 		);
-		if (!charactersRequired)
-		{
-			const auto lastError = Win32::GetLastError();
-			throw Error::Win32Error("GetDateFormatEx() failed", lastError);
-		}
+		if (not charactersRequired)
+			throw Error::Win32Error(Win32::GetLastError(), "GetDateFormatEx() failed");
 
 		return formattedString.c_str();
 	}
@@ -212,11 +188,8 @@ export namespace Boring32::Time
 			0,
 			nullptr
 		);
-		if (!charactersRequired)
-		{
-			const auto lastError = Win32::GetLastError();
-			throw Error::Win32Error("GetDateFormatEx() failed", lastError);
-		}
+		if (not charactersRequired)
+			throw Error::Win32Error(Win32::GetLastError(), "GetDateFormatEx() failed");
 
 		std::wstring formattedString(charactersRequired, '\0');
 		charactersRequired = Win32::GetDateFormatEx(
@@ -228,11 +201,8 @@ export namespace Boring32::Time
 			static_cast<int>(formattedString.size()),
 			nullptr
 		);
-		if (!charactersRequired)
-		{
-			const auto lastError = Win32::GetLastError();
-			throw Error::Win32Error("GetDateFormatEx() failed", lastError);
-		}
+		if (not charactersRequired)
+			throw Error::Win32Error(Win32::GetLastError(), "GetDateFormatEx() failed");
 
 		return formattedString.c_str();
 	}

--- a/src/Boring32/Util/boring32-util_functions.ixx
+++ b/src/Boring32/Util/boring32-util_functions.ixx
@@ -60,11 +60,8 @@ export namespace Boring32::Util
 		{
 			filePath.resize(filePath.size() + blockSize);
 			status = Win32::GetModuleFileNameW(nullptr, &filePath[0], static_cast<Win32::DWORD>(filePath.size()));
-			if (!status)
-			{
-				const auto lastError = Win32::GetLastError();
-				throw Error::Win32Error("GetModuleFileNameW() failed", lastError);
-			}
+			if (not status)
+				throw Error::Win32Error(Win32::GetLastError(), "GetModuleFileNameW() failed");
 		}
 
 		const Win32::HRESULT result = Win32::PathCchRemoveFileSpec(&filePath[0], filePath.size());
@@ -82,11 +79,8 @@ export namespace Boring32::Util
 			.dwLowDateTime = li.LowPart,
 			.dwHighDateTime = static_cast<Win32::DWORD>(li.HighPart)
 		};
-		if (!Win32::FileTimeToSystemTime(&ft, &st))
-		{
-			const auto lastError = Win32::GetLastError();
-			throw Error::Win32Error("FileTimeToSystemTime() failed", lastError);
-		}
+		if (not Win32::FileTimeToSystemTime(&ft, &st))
+			throw Error::Win32Error(Win32::GetLastError(), "FileTimeToSystemTime() failed");
 		return st;
 	}
 

--- a/src/Boring32/Util/boring32-util_globallyuniqueid.ixx
+++ b/src/Boring32/Util/boring32-util_globallyuniqueid.ixx
@@ -49,7 +49,7 @@ export namespace Boring32::Util
 			// https://docs.microsoft.com/en-us/windows/win32/rpc/rpc-return-values
 			// Not sure if this works, as RPC_STATUS is a long, not an unsigned long
 			if (status != Win32::_RPC_S_OK)
-				throw Error::Win32Error("UuidFromStringW() failed", status);
+				throw Error::Win32Error(status, "UuidFromStringW() failed");
 		}
 
 		GloballyUniqueID(const GUID& guid)

--- a/src/Boring32/WinHttp/boring32-winhttp_asyncwebsocket_statuscallback.cpp
+++ b/src/Boring32/WinHttp/boring32-winhttp_asyncwebsocket_statuscallback.cpp
@@ -5,7 +5,7 @@ import :error;
 
 namespace Boring32::WinHttp::WebSockets
 {
-	void Print(const DWORD dwInternetStatus)
+	void Print(const Win32::DWORD dwInternetStatus)
 	{
 		//static const std::map<DWORD, std::wstring> InternetStatus{
 		//{WINHTTP_CALLBACK_STATUS_RESOLVING_NAME, L"WINHTTP_CALLBACK_STATUS_RESOLVING_NAME"},
@@ -74,12 +74,7 @@ namespace Boring32::WinHttp::WebSockets
 
 				if (!Win32::WinHttp::WinHttpReceiveResponse(hInternet, 0))
 				{
-					const auto lastError = Win32::GetLastError();
-					Error::Win32Error ex(
-						"WinHttpReceiveResponse() failed on initial connection",
-						lastError
-					);
-
+					Error::Win32Error ex(Win32::GetLastError(), "WinHttpReceiveResponse() failed on initial connection");
 					std::wcout << ex.what() << std::endl;
 				}
 
@@ -96,7 +91,7 @@ namespace Boring32::WinHttp::WebSockets
 					Win32::DWORD statusCode = 0;
 					Win32::DWORD statusCodeSize = sizeof(statusCode);
 					// https://docs.microsoft.com/en-us/windows/win32/api/winhttp/nf-winhttp-winhttpqueryheaders
-					const bool success = Win32::WinHttp::WinHttpQueryHeaders(
+					bool success = Win32::WinHttp::WinHttpQueryHeaders(
 						hInternet,
 						Win32::WinHttp::_WINHTTP_QUERY_STATUS_CODE | Win32::WinHttp::_WINHTTP_QUERY_FLAG_NUMBER,
 						(Win32::LPCWSTR)Win32::WinHttp::_WINHTTP_HEADER_NAME_BY_INDEX,
@@ -105,10 +100,7 @@ namespace Boring32::WinHttp::WebSockets
 						(Win32::LPDWORD)Win32::WinHttp::_WINHTTP_NO_HEADER_INDEX
 					);
 					if (!success)
-					{
-						const auto lastError = Win32::GetLastError();
-						throw Error::Win32Error("WinHttpQueryHeaders() failed", lastError);
-					}
+						throw Error::Win32Error(Win32::GetLastError(), "WinHttpQueryHeaders() failed");
 
 					switch (statusCode)
 					{
@@ -159,7 +151,7 @@ namespace Boring32::WinHttp::WebSockets
 				try
 				{
 					if (read.Status != ReadResultStatus::Initiated 
-						&& read.Status != ReadResultStatus::PartialRead)
+						and read.Status != ReadResultStatus::PartialRead)
 					{
 						std::wcerr << L"read in an unexpected status" << std::endl;
 						return;
@@ -219,7 +211,7 @@ namespace Boring32::WinHttp::WebSockets
 				
 				AsyncWebSocket* socket = (AsyncWebSocket*)dwContext;
 				socket->m_status = WebSocketStatus::Error;
-				Error::Win32Error err("Error occurred in async socket callback", (DWORD)requestError->dwError);
+				Error::Win32Error err((Win32::DWORD)requestError->dwError, "Error occurred in async socket callback");
 				switch (requestError->dwResult)
 				{
 					case Win32::WinHttp::_API_RECEIVE_RESPONSE:

--- a/src/Boring32/WinHttp/boring32-winhttp_decomposedurl.ixx
+++ b/src/Boring32/WinHttp/boring32-winhttp_decomposedurl.ixx
@@ -36,8 +36,8 @@ export namespace Boring32::WinHttp
 				.dwExtraInfoLength = (DWORD)-1
 			};
 			// https://learn.microsoft.com/en-us/windows/win32/api/winhttp/nf-winhttp-winhttpcrackurl
-			if (auto lastError = Win32::GetLastError(); not Win32::WinHttp::WinHttpCrackUrl(m_url.c_str(), 0, 0, &components))
-				throw Error::Win32Error("WinHttpCrackUrl() failed", lastError);
+			if (not Win32::WinHttp::WinHttpCrackUrl(m_url.c_str(), 0, 0, &components))
+				throw Error::Win32Error(Win32::GetLastError(), "WinHttpCrackUrl() failed");
 
 			// there's also nScheme
 			m_scheme = { components.lpszScheme, components.dwSchemeLength };

--- a/src/Boring32/WinHttp/boring32-winhttp_httpwebclient.ixx
+++ b/src/Boring32/WinHttp/boring32-winhttp_httpwebclient.ixx
@@ -116,8 +116,8 @@ export namespace Boring32::WinHttp
 				(Win32::LPCWSTR)Win32::WinHttp::_WINHTTP_NO_PROXY_BYPASS,
 				0
 			);
-			if (auto lastError = Win32::GetLastError(); not m_hSession)
-				throw Error::Win32Error("WinHttpOpen() failed", lastError);
+			if (not m_hSession)
+				throw Error::Win32Error(Win32::GetLastError(), "WinHttpOpen() failed");
 
 			//if (m_proxy.empty() == false)
 			//{
@@ -131,8 +131,8 @@ export namespace Boring32::WinHttp
 				m_port,
 				0
 			);
-			if (auto lastError = Win32::GetLastError(); not m_hConnect)
-				throw Error::Win32Error("WinHttpConnect() failed", lastError);
+			if (not m_hConnect)
+				throw Error::Win32Error(Win32::GetLastError(), "WinHttpConnect() failed");
 		}
 
 		private:
@@ -167,8 +167,8 @@ export namespace Boring32::WinHttp
 				(Win32::LPCWSTR*)acceptTypes,
 				Win32::WinHttp::_WINHTTP_FLAG_SECURE
 			);
-			if (auto lastError = Win32::GetLastError(); not hRequest)
-				throw Error::Win32Error("WinHttpOpenRequest() failed", lastError);
+			if (not hRequest)
+				throw Error::Win32Error(Win32::GetLastError(), "WinHttpOpenRequest() failed");
 
 			if (m_ignoreSslErrors)
 			{
@@ -183,8 +183,8 @@ export namespace Boring32::WinHttp
 					&flags,
 					sizeof(flags)
 				);
-				if (auto lastError = Win32::GetLastError(); not succeeded)
-					throw Error::Win32Error("WinHttpSetOption() failed", lastError);
+				if (not succeeded)
+					throw Error::Win32Error(Win32::GetLastError(), "WinHttpSetOption() failed");
 			}
 
 			// https://docs.microsoft.com/en-us/windows/win32/api/winhttp/nf-winhttp-winhttpsendrequest
@@ -197,13 +197,13 @@ export namespace Boring32::WinHttp
 				static_cast<Win32::DWORD>(requestBody.size()),
 				reinterpret_cast<Win32::DWORD_PTR>(this)
 			);
-			if (auto lastError = Win32::GetLastError(); not succeeded)
-				throw Error::Win32Error("WinHttpSendRequest() failed", lastError);
+			if (not succeeded)
+				throw Error::Win32Error(Win32::GetLastError(), "WinHttpSendRequest() failed");
 
 			// https://docs.microsoft.com/en-us/windows/win32/api/winhttp/nf-winhttp-winhttpreceiveresponse
 			succeeded = Win32::WinHttp::WinHttpReceiveResponse(hRequest.Get(), nullptr);
-			if (auto lastError = Win32::GetLastError(); not succeeded)
-				throw Error::Win32Error("WinHttpReceiveResponse() failed", lastError);
+			if (not succeeded)
+				throw Error::Win32Error(Win32::GetLastError(), "WinHttpReceiveResponse() failed");
 
 			// Get the status code of the response
 			Win32::DWORD statusCode = 0;
@@ -224,8 +224,8 @@ export namespace Boring32::WinHttp
 			do
 			{
 				// https://docs.microsoft.com/en-us/windows/win32/api/winhttp/nf-winhttp-winhttpquerydataavailable
-				if (const auto lastError = Win32::GetLastError(); not Win32::WinHttp::WinHttpQueryDataAvailable(hRequest.Get(), &bytesOfDataAvailable))
-					throw Error::Win32Error("WinHttpQueryDataAvailable() failed", lastError);
+				if (not Win32::WinHttp::WinHttpQueryDataAvailable(hRequest.Get(), &bytesOfDataAvailable))
+					throw Error::Win32Error(Win32::GetLastError(), "WinHttpQueryDataAvailable() failed");
 				if (bytesOfDataAvailable == 0)
 					continue;
 
@@ -240,8 +240,8 @@ export namespace Boring32::WinHttp
 					bytesOfDataAvailable,
 					&downloadedBytes
 				);
-				if (auto lastError = Win32::GetLastError(); not succeeded)
-					throw Error::Win32Error("WinHttpQueryDataAvailable() failed", lastError);
+				if (not succeeded)
+					throw Error::Win32Error(Win32::GetLastError(), "WinHttpQueryDataAvailable() failed");
 
 				response.append(outBuffer.begin(), outBuffer.end());
 			} while (bytesOfDataAvailable > 0);

--- a/src/Boring32/WinHttp/boring32-winhttp_proxyinfo.ixx
+++ b/src/Boring32/WinHttp/boring32-winhttp_proxyinfo.ixx
@@ -21,8 +21,8 @@ export namespace Boring32::WinHttp
 		)
 		{
 			// https://docs.microsoft.com/en-us/windows/win32/api/winhttp/nf-winhttp-winhttpgetproxyforurl
-			if (auto lastError = Win32::GetLastError(); not Win32::WinHttp::WinHttpGetProxyForUrl(session, url.c_str(), &options, &m_info))
-				throw Error::Win32Error("WinHttpGetProxyForUrl() failed", lastError);
+			if (not Win32::WinHttp::WinHttpGetProxyForUrl(session, url.c_str(), &options, &m_info))
+				throw Error::Win32Error(Win32::GetLastError(), "WinHttpGetProxyForUrl() failed");
 			m_mustRelease = true;
 		}
 			
@@ -62,8 +62,8 @@ export namespace Boring32::WinHttp
 			autoProxyOptions.lpvReserved = 0;
 			autoProxyOptions.dwReserved = 0;
 			// https://docs.microsoft.com/en-us/windows/win32/api/winhttp/nf-winhttp-winhttpgetproxyforurl
-			if (auto lastError = Win32::GetLastError(); !Win32::WinHttp::WinHttpGetProxyForUrl(session, url.c_str(), &autoProxyOptions, &m_info))
-				throw Error::Win32Error("WinHttpGetProxyForUrl() failed", lastError);
+			if (not Win32::WinHttp::WinHttpGetProxyForUrl(session, url.c_str(), &autoProxyOptions, &m_info))
+				throw Error::Win32Error(Win32::GetLastError(), "WinHttpGetProxyForUrl() failed");
 		}
 
 		void SetAllInfo(const std::wstring& proxy, const std::wstring& proxyBypass, const Win32::DWORD accessType)
@@ -81,8 +81,8 @@ export namespace Boring32::WinHttp
 			if (not m_info.lpszProxy)
 				throw Boring32::Error::Boring32Error("No proxy set");
 			// https://docs.microsoft.com/en-us/windows/win32/api/winhttp/nf-winhttp-winhttpsetoption
-			if (auto lastError = Win32::GetLastError(); not Win32::WinHttp::WinHttpSetOption(session, Win32::WinHttp::_WINHTTP_OPTION_PROXY, &m_info, sizeof(m_info)))
-				throw Error::Win32Error("WinHttpSetOption() failed", lastError);
+			if (not Win32::WinHttp::WinHttpSetOption(session, Win32::WinHttp::_WINHTTP_OPTION_PROXY, &m_info, sizeof(m_info)))
+				throw Error::Win32Error(Win32::GetLastError(), "WinHttpSetOption() failed");
 		}
 
 		private:

--- a/src/Boring32/WinHttp/boring32-winhttp_session.ixx
+++ b/src/Boring32/WinHttp/boring32-winhttp_session.ixx
@@ -125,21 +125,18 @@ export namespace Boring32::WinHttp
 				? (wchar_t*)Win32::WinHttp::_WINHTTP_NO_PROXY_BYPASS
 				: m_proxyBypass.c_str();
 			// https://docs.microsoft.com/en-us/windows/win32/api/winhttp/nf-winhttp-winhttpopen
-			const Win32::WinHttp::HINTERNET handle = Win32::WinHttp::WinHttpOpen(
+			Win32::WinHttp::HINTERNET handle = Win32::WinHttp::WinHttpOpen(
 				m_userAgent.c_str(),
 				static_cast<Win32::DWORD>(m_proxyType),
 				proxyType,
 				proxyBypass,
 				0
 			);
-			if (!handle)
-			{
-				const auto lastError = Win32::GetLastError();
+			if (not handle)
 				Error::ThrowNested(
-					Error::Win32Error("WinHttpOpen() failed", lastError),
+					Error::Win32Error(Win32::GetLastError(), "WinHttpOpen() failed"),
 					WinHttpError("Failed to open WinHttpSession handle")
 				);
-			}
 
 			m_session = SharedWinHttpSession(handle, Win32::WinHttp::WinHttpCloseHandle);
 		}

--- a/src/Boring32/WinSock/boring32-winsock_functions.ixx
+++ b/src/Boring32/WinSock/boring32-winsock_functions.ixx
@@ -39,9 +39,8 @@ export namespace Boring32::WinSock
 		Win32::PCSTR ipCString = Win32::WinSock::inet_ntop(Win32::WinSock::AddressFamily::IPv6, &converted, &out[0], Win32::WinSock::_INET6_ADDRSTRLEN);
 		if (!ipCString)
 		{
-			const auto lastError = Win32::WinSock::WSAGetLastError();
 			Error::ThrowNested(
-				Error::Win32Error("inet_ntop() failed", lastError, L"Ws2_32.dll"),
+				Error::Win32Error(Win32::WinSock::WSAGetLastError(), "inet_ntop() failed", L"Ws2_32.dll"),
 				WinSockError("Could not convert IPv6 network address string")
 			);
 		}
@@ -59,9 +58,8 @@ export namespace Boring32::WinSock
 		Win32::PCSTR ipCString = Win32::WinSock::inet_ntop(Win32::WinSock::AddressFamily::IPv4, &converted, &out[0], Win32::WinSock::_INET_ADDRSTRLEN);
 		if (!ipCString)
 		{
-			const auto lastError = Win32::WinSock::WSAGetLastError();
 			Error::ThrowNested(
-				Error::Win32Error("inet_ntop() failed", lastError, L"Ws2_32.dll"),
+				Error::Win32Error(Win32::WinSock::WSAGetLastError(), "inet_ntop() failed", L"Ws2_32.dll"),
 				WinSockError("Could not convert IPv4 network address string")
 			);
 		}
@@ -107,7 +105,7 @@ export namespace Boring32::WinSock
 		if (result != 0)
 		{
 			Error::ThrowNested(
-				Error::Win32Error("GetAddrInfoW() failed", result, L"Ws2_32.dll"),
+				Error::Win32Error(result, "GetAddrInfoW() failed", L"Ws2_32.dll"),
 				WinSockError("Could not get domain addr info")
 			);
 		}
@@ -175,13 +173,13 @@ export namespace Boring32::WinSock
 			&cancelHandle
 		);
 		if (error != Win32::WinSock::_WSA_IO_PENDING) Error::ThrowNested(
-			Error::Win32Error("GetAddrInfoExW() failed", error, L"Ws2_32.dll"),
+			Error::Win32Error(error, "GetAddrInfoExW() failed", L"Ws2_32.dll"),
 			WinSockError("Could not get domain addr info")
 		);
 		e.WaitOnEvent();
 
 		if (ov.InternalHigh != Win32::ErrorCodes::NoError) Error::ThrowNested(
-			Error::Win32Error("GetAddrInfoExW() overlapped op failed", (Win32::DWORD)ov.InternalHigh),
+			Error::Win32Error((Win32::DWORD)ov.InternalHigh, "GetAddrInfoExW() overlapped op failed"),
 			WinSockError("Could not get domain addr info")
 		);
 
@@ -245,13 +243,13 @@ export namespace Boring32::WinSock
 			nullptr
 		);
 		if (error != Win32::WinSock::_WSA_IO_PENDING) Error::ThrowNested(
-			Error::Win32Error("GetAddrInfoExW() failed", error, L"Ws2_32.dll"),
+			Error::Win32Error(error, "GetAddrInfoExW() failed", L"Ws2_32.dll"),
 			WinSockError("Could not get domain addr info")
 		);
 
 		opCompleted.WaitOnEvent();
 		if (ov.InternalHigh != Win32::ErrorCodes::NoError) Error::ThrowNested(
-			Error::Win32Error("GetAddrInfoExW() overlapped op failed", (Win32::DWORD)ov.InternalHigh),
+			Error::Win32Error((Win32::DWORD)ov.InternalHigh, "GetAddrInfoExW() overlapped op failed"),
 			WinSockError("Could not get domain addr info")
 		);
 

--- a/src/Boring32/WinSock/boring32-winsock_resolvedname.ixx
+++ b/src/Boring32/WinSock/boring32-winsock_resolvedname.ixx
@@ -42,7 +42,7 @@ export namespace Boring32::WinSock
 				&addrInfoResult
 			);
 			if (status)
-				throw Error::Win32Error("GetAddrInfoW() failed", status, L"ws2_32.dll");
+				throw Error::Win32Error(status, "GetAddrInfoW() failed", L"ws2_32.dll");
 			if (not addrInfoResult)
 				throw WinSockError("GetAddrInfoW() did not find any valid results");
 

--- a/src/Boring32/WinSock/boring32-winsock_socket.ixx
+++ b/src/Boring32/WinSock/boring32-winsock_socket.ixx
@@ -37,7 +37,7 @@ export namespace Boring32::WinSock
 			{
 				const auto lastError = Win32::WinSock::WSAGetLastError();
 				Error::ThrowNested(
-					Error::Win32Error("socket() failed", lastError, L"ws2_32.dll"),
+					Error::Win32Error(lastError, "socket() failed", L"ws2_32.dll"),
 					WinSockError("Failed to open socket")
 				);
 			}

--- a/src/Boring32/WinSock/boring32-winsock_tcpsocket.ixx
+++ b/src/Boring32/WinSock/boring32-winsock_tcpsocket.ixx
@@ -42,7 +42,7 @@ export namespace Boring32::WinSock
 			{
 				const auto lastError = Win32::WinSock::WSAGetLastError();
 				Error::ThrowNested(
-					Error::Win32Error("socket() failed", lastError, L"ws2_32.dll"),
+					Error::Win32Error(lastError, "socket() failed", L"ws2_32.dll"),
 					WinSockError("Failed to open socket")
 				);
 			}
@@ -86,16 +86,15 @@ export namespace Boring32::WinSock
 			// See https://social.msdn.microsoft.com/Forums/en-US/2202d113-212d-420d-9e7b-11268de9ce90/win32-tcp-connect-timeout
 			// and https://docs.microsoft.com/en-us/windows/win32/winsock/windows-sockets-error-codes-2
 			// https://docs.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-connect
-			const int connectionResult = Win32::WinSock::connect(
+			int connectionResult = Win32::WinSock::connect(
 				m_socket,
 				m_addrPtr->ai_addr,
 				static_cast<int>(m_addrPtr->ai_addrlen)
 			);
 			if (connectionResult == Win32::WinSock::_SOCKET_ERROR)
 			{
-				const auto lastError = Win32::WinSock::WSAGetLastError();
 				Error::ThrowNested(
-					Error::Win32Error("connect() failed", lastError, L"ws2_32.dll"),
+					Error::Win32Error(Win32::WinSock::WSAGetLastError(), "connect() failed", L"ws2_32.dll"),
 					WinSockError("Failed to connect socket")
 				);
 			}
@@ -135,9 +134,8 @@ export namespace Boring32::WinSock
 				);
 				if (sentBytes == Win32::WinSock::_SOCKET_ERROR)
 				{
-					const auto lastError = Win32::WinSock::WSAGetLastError();
 					Error::ThrowNested(
-						Error::Win32Error("send() failed", lastError, L"ws2_32.dll"),
+						Error::Win32Error(Win32::WinSock::WSAGetLastError(), "send() failed", L"ws2_32.dll"),
 						WinSockError("Failed to send data through socket")
 					);
 				}
@@ -157,9 +155,8 @@ export namespace Boring32::WinSock
 			const int actualBytesRead = Win32::WinSock::recv(m_socket, reinterpret_cast<char*>(&recvbuf[0]), bytesToRead, 0);
 			if (actualBytesRead < 0)
 			{
-				const auto lastError = Win32::WinSock::WSAGetLastError();
 				Error::ThrowNested(
-					Error::Win32Error("recv() failed", lastError, L"ws2_32.dll"),
+					Error::Win32Error(Win32::WinSock::WSAGetLastError(), "recv() failed", L"ws2_32.dll"),
 					WinSockError("Failed to receive data through socket")
 				);
 			}
@@ -203,9 +200,8 @@ export namespace Boring32::WinSock
 			);
 			if (optResult == Win32::WinSock::_SOCKET_ERROR)
 			{
-				const auto lastError = Win32::WinSock::WSAGetLastError();
 				Error::ThrowNested(
-					Error::Win32Error("getsockopt() failed", lastError, L"ws2_32.dll"),
+					Error::Win32Error(Win32::WinSock::WSAGetLastError(), "getsockopt() failed", L"ws2_32.dll"),
 					WinSockError("TTL option is not supported")
 				);
 			}
@@ -221,9 +217,8 @@ export namespace Boring32::WinSock
 			);
 			if (optResult == Win32::WinSock::_SOCKET_ERROR)
 			{
-				const auto lastError = Win32::WinSock::WSAGetLastError();
 				Error::ThrowNested(
-					Error::Win32Error("setsockopt() failed", lastError, L"ws2_32.dll"),
+					Error::Win32Error(Win32::WinSock::WSAGetLastError(), "setsockopt() failed", L"ws2_32.dll"),
 					WinSockError("Failed to set option")
 				);
 			}
@@ -245,13 +240,10 @@ export namespace Boring32::WinSock
 				&optLen
 			);
 			if (optResult == Win32::WinSock::_SOCKET_ERROR)
-			{
-				const auto lastError = Win32::WinSock::WSAGetLastError();
 				Error::ThrowNested(
-					Error::Win32Error("getsockopt() failed", lastError, L"ws2_32.dll"),
+					Error::Win32Error(Win32::WinSock::WSAGetLastError(), "getsockopt() failed", L"ws2_32.dll"),
 					WinSockError("RT option is not supported")
 				);
-			}
 
 			optVal = timeoutSeconds;
 			optResult = Win32::WinSock::setsockopt(
@@ -262,13 +254,10 @@ export namespace Boring32::WinSock
 				optLen
 			);
 			if (optResult == Win32::WinSock::_SOCKET_ERROR)
-			{
-				const auto lastError = Win32::WinSock::WSAGetLastError();
 				Error::ThrowNested(
-					Error::Win32Error("setsockopt() failed", lastError, L"ws2_32.dll"),
+					Error::Win32Error(Win32::WinSock::WSAGetLastError(), "setsockopt() failed", L"ws2_32.dll"),
 					WinSockError("Failed to set RT option")
 				);
-			}
 		}
 
 		const std::wstring& GetHost() const noexcept

--- a/src/Boring32/WinSock/boring32-winsock_winsockinit.ixx
+++ b/src/Boring32/WinSock/boring32-winsock_winsockinit.ixx
@@ -47,7 +47,7 @@ export namespace Boring32::WinSock
 			// https://docs.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-wsacleanup
 			const int error = Win32::WinSock::WSACleanup();
 			if (error) Error::ThrowNested(
-				Error::Win32Error("WSACleanup() failed", error, L"Ws2_32.dll"),
+				Error::Win32Error(error, "WSACleanup() failed", L"Ws2_32.dll"),
 				WinSockError("Failed to cleanup WinSock")
 			);
 			m_lowVersion = 0;
@@ -81,7 +81,7 @@ export namespace Boring32::WinSock
 			//https://docs.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-wsastartup
 			int error = Win32::WinSock::WSAStartup(Win32::MakeWord(m_highVersion, m_lowVersion), &m_wsaData);
 			if (error) Error::ThrowNested(
-				Error::Win32Error("WSAStartup() failed", error, L"Ws2_32.dll"),
+				Error::Win32Error(error, "WSAStartup() failed", L"Ws2_32.dll"),
 				WinSockError("Failed to initialise WinSock")
 			);
 		}

--- a/src/Boring32/WirelessLAN/boring32-wirelesslan_session.ixx
+++ b/src/Boring32/WirelessLAN/boring32-wirelesslan_session.ixx
@@ -52,7 +52,7 @@ export namespace Boring32::WirelessLAN
 				&wlanHandle
 			);
 			if (status != Win32::ErrorCodes::Success)
-				throw Boring32::Error::Win32Error("WlanOpenHandle() failed", status);
+				throw Boring32::Error::Win32Error(status, "WlanOpenHandle() failed");
 			m_wlanHandle = CreateSharedWLANHandle(wlanHandle);
 			return m_wlanHandle;
 		}

--- a/src/Boring32/WirelessLAN/boring32-wirelesslan_wirelessinterface.ixx
+++ b/src/Boring32/WirelessLAN/boring32-wirelesslan_wirelessinterface.ixx
@@ -35,7 +35,7 @@ namespace Boring32::WirelessLAN
 			&opcodeType
 		);
 		if (status != Win32::ErrorCodes::Success)
-			throw Error::Win32Error("WlanQueryInterface() failed", status);
+			throw Error::Win32Error(status, "WlanQueryInterface() failed");
 		UniqueWLANMemory cleanup(pWlanAllocatedMemory);
 		return T(*reinterpret_cast<T*>(pWlanAllocatedMemory));
 	}
@@ -68,7 +68,7 @@ namespace Boring32::WirelessLAN
 			&opcodeType
 		);
 		if (status != Win32::ErrorCodes::Success)
-			throw Error::Win32Error("WlanQueryInterface() failed", status);
+			throw Error::Win32Error(status, "WlanQueryInterface() failed");
 		UniqueWLANMemory cleanup(pWlanAllocatedMemory);
 		auto results = reinterpret_cast<Win32::WLAN_AUTH_CIPHER_PAIR_LIST*>(pWlanAllocatedMemory);
 		std::vector<Win32::DOT11_AUTH_CIPHER_PAIR> returnVal;
@@ -246,7 +246,7 @@ export namespace Boring32::WirelessLAN
 					&capability
 				);
 				if (status != Win32::ErrorCodes::Success)
-					throw Error::Win32Error("WlanGetInterfaceCapability() failed", status);
+					throw Error::Win32Error(status, "WlanGetInterfaceCapability() failed");
 				UniqueWLANMemory cleanup(capability);
 				return *capability;
 			}

--- a/src/Boring32/WirelessLAN/boring32-wirelesslan_wirelessinterfaces.ixx
+++ b/src/Boring32/WirelessLAN/boring32-wirelesslan_wirelessinterfaces.ixx
@@ -19,7 +19,7 @@ export namespace Boring32::WirelessLAN
 			// https://docs.microsoft.com/en-us/windows/win32/api/wlanapi/nf-wlanapi-wlanenuminterfaces
 			Win32::DWORD status = Win32::WlanEnumInterfaces(m_session.get(), nullptr, &pIfList);
 			if (status != Win32::ErrorCodes::Success)
-				throw Error::Win32Error("WlanEnumInterfaces() failed", status);
+				throw Error::Win32Error(status, "WlanEnumInterfaces() failed");
 			UniqueWLANMemory interfaceList = UniqueWLANMemory(pIfList);
 
 			std::vector<WirelessInterface> returnVal;

--- a/src/Boring32/XAudio2/boring32-xaudio2_functions.ixx
+++ b/src/Boring32/XAudio2/boring32-xaudio2_functions.ixx
@@ -23,10 +23,7 @@ export namespace Boring32::XAudio2
     {
         Win32::DWORD result = Win32::SetFilePointer(hFile, 0, nullptr, Win32::FileBegin);
         if (result == Win32::InvalidSetFilePointer)
-            throw Error::Win32Error(
-                "Win32::SetFilePointer() failed",
-                Win32::GetLastError()
-            );
+            throw Error::Win32Error(Win32::GetLastError(), "Win32::SetFilePointer() failed");
 
         Win32::DWORD dwChunkType;
         Win32::DWORD dwChunkDataSize;
@@ -39,19 +36,19 @@ export namespace Boring32::XAudio2
         while (hr == Win32::S_Ok)
         {
             Win32::DWORD dwRead;
-            if (auto lastError = Win32::GetLastError(); not Win32::ReadFile(hFile, &dwChunkType, sizeof(Win32::DWORD), &dwRead, nullptr))
-                throw Error::Win32Error("Win32::ReadFile() failed", lastError);
+            if (not Win32::ReadFile(hFile, &dwChunkType, sizeof(Win32::DWORD), &dwRead, nullptr))
+                throw Error::Win32Error(Win32::GetLastError(), "Win32::ReadFile() failed");
 
-            if (auto lastError = Win32::GetLastError(); not Win32::ReadFile(hFile, &dwChunkDataSize, sizeof(Win32::DWORD), &dwRead, nullptr))
-                throw Error::Win32Error("Win32::ReadFile() failed", lastError);
+            if (not Win32::ReadFile(hFile, &dwChunkDataSize, sizeof(Win32::DWORD), &dwRead, nullptr))
+                throw Error::Win32Error(Win32::GetLastError(), "Win32::ReadFile() failed");
 
             switch (dwChunkType)
             {
                 case fourccRIFF:
                     dwRIFFDataSize = dwChunkDataSize;
                     dwChunkDataSize = 4;
-                    if (auto lastError = Win32::GetLastError(); not Win32::ReadFile(hFile, &dwFileType, sizeof(Win32::DWORD), &dwRead, nullptr))
-                        throw Error::Win32Error("Win32::ReadFile() failed", lastError);
+                    if (not Win32::ReadFile(hFile, &dwFileType, sizeof(Win32::DWORD), &dwRead, nullptr))
+                        throw Error::Win32Error(Win32::GetLastError(), "Win32::ReadFile() failed");
                     break;
 
                 default:
@@ -61,8 +58,8 @@ export namespace Boring32::XAudio2
                         nullptr,
                         Win32::FileCurrent
                     );
-                    if (auto lastError = Win32::GetLastError(); result == Win32::InvalidSetFilePointer)
-                        throw Error::Win32Error("Win32::SetFilePointer() failed",lastError);
+                    if (result == Win32::InvalidSetFilePointer)
+                        throw Error::Win32Error(Win32::GetLastError(), "Win32::SetFilePointer() failed");
             }
 
             dwOffset += sizeof(Win32::DWORD) * 2;


### PR DESCRIPTION
Moved the errorCode parameter to the beginning of all constructors for Win32Error and updated all references. This simplifies the client code by allowing to call GetLastError() as the first parameter without worrying about the error code global being reset.